### PR TITLE
feat: new parameter for target window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ using VCDiff.Shared;
 void DoEncode() {
     using(FileStream output = new FileStream("...some output path", FileMode.Create, FileAccess.Write))
     using(FileStream dict = new FileStream("..dictionary / old file path", FileMode.Open, FileAccess.Read))
-    using(FileStream target = new FileStream("..target data / new data path", FileMode.Open, FileMode.Read)) {
+    using(FileStream target = new FileStream("..target data / new data path", FileMode.Open, FileAcces.Read)) {
         VcEncoder coder = new VcEncoder(dict, target, output);
         VCDiffResult result = coder.Encode(); //encodes with no checksum and not interleaved
         if(result != VCDiffResult.SUCCESS) {
@@ -97,7 +97,7 @@ using VCDiff.Shared;
 void DoDecode() {
     using (FileStream output = new FileStream("...some output path", FileMode.Create, FileAccess.Write))
     using (FileStream dict = new FileStream("..dictionary / old file path", FileMode.Open, FileAccess.Read))
-    using (FileStream target = new FileStream("..delta encoded part", FileMode.Open, FileMode.Read)) {
+    using (FileStream target = new FileStream("..delta encoded part", FileMode.Open, FileAcces.Read)) {
         VCDecoder decoder = new VCDecoder(dict, target, output);
 
         // The header of the delta file must be available before the first call to decoder.Decode().

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ using VCDiff.Shared;
 void DoEncode() {
     using(FileStream output = new FileStream("...some output path", FileMode.Create, FileAccess.Write))
     using(FileStream dict = new FileStream("..dictionary / old file path", FileMode.Open, FileAccess.Read))
-    using(FileStream target = new FileStream("..target data / new data path", FileMode.Open, FileAcces.Read)) {
+    using(FileStream target = new FileStream("..target data / new data path", FileMode.Open, FileAccess.Read)) {
         VcEncoder coder = new VcEncoder(dict, target, output);
         VCDiffResult result = coder.Encode(); //encodes with no checksum and not interleaved
         if(result != VCDiffResult.SUCCESS) {
@@ -97,7 +97,7 @@ using VCDiff.Shared;
 void DoDecode() {
     using (FileStream output = new FileStream("...some output path", FileMode.Create, FileAccess.Write))
     using (FileStream dict = new FileStream("..dictionary / old file path", FileMode.Open, FileAccess.Read))
-    using (FileStream target = new FileStream("..delta encoded part", FileMode.Open, FileAcces.Read)) {
+    using (FileStream target = new FileStream("..delta encoded part", FileMode.Open, FileAccess.Read)) {
         VCDecoder decoder = new VCDecoder(dict, target, output);
 
         // The header of the delta file must be available before the first call to decoder.Decode().

--- a/src/VCDiff/Decoders/VcDecoder.cs
+++ b/src/VCDiff/Decoders/VcDecoder.cs
@@ -15,6 +15,7 @@ namespace VCDiff.Decoders
         private readonly Stream outputStream;
         private readonly IByteBuffer delta;
         private readonly IByteBuffer source;
+        private readonly int maxTargetFileSize;
         private CustomCodeTableDecoder? customTable;
         private static readonly byte[] MagicBytes = { 0xD6, 0xC3, 0xC4, 0x00, 0x00 };
 
@@ -34,19 +35,22 @@ namespace VCDiff.Decoders
         /// <param name="source">The dictionary stream, or the base file.</param>
         /// <param name="delta">The stream containing the VCDIFF delta.</param>
         /// <param name="outputStream">The stream to write the output in.</param>
-        public VcDecoder(Stream source, Stream delta, Stream outputStream)
+        /// <param name="maxTargetFileSize">The maximum target file size (and target window size) in bytes</param>
+        public VcDecoder(Stream source, Stream delta, Stream outputStream, int maxTargetFileSize = WindowDecoder.DefaultMaxTargetFileSize)
         {
             this.delta = new ByteStreamReader(delta);
             this.source = new ByteStreamReader(source);
             this.outputStream = outputStream;
+            this.maxTargetFileSize = maxTargetFileSize;
             this.IsInitialized = false;
         }
 
-        internal VcDecoder(IByteBuffer dict, IByteBuffer delta, Stream outputStream)
+        internal VcDecoder(IByteBuffer dict, IByteBuffer delta, Stream outputStream, int maxTargetFileSize = WindowDecoder.DefaultMaxTargetFileSize)
         {
             this.delta = delta;
             this.source = dict;
             this.outputStream = outputStream;
+            this.maxTargetFileSize = maxTargetFileSize;
             this.IsInitialized = false;
         }
 
@@ -162,7 +166,7 @@ namespace VCDiff.Decoders
             while (delta.CanRead)
             {
                 //delta is streamed in order aka not random access
-                WindowDecoder w = new WindowDecoder(source.Length, delta);
+                WindowDecoder w = new WindowDecoder(source.Length, delta, maxTargetFileSize);
 
                 if (w.Decode(this.IsSDCHFormat))
                 {
@@ -239,7 +243,7 @@ namespace VCDiff.Decoders
             while (delta.CanRead)
             {
                 //delta is streamed in order aka not random access
-                WindowDecoder w = new WindowDecoder(source.Length, delta);
+                WindowDecoder w = new WindowDecoder(source.Length, delta, maxTargetFileSize);
 
                 if (w.Decode(this.IsSDCHFormat))
                 {

--- a/src/VCDiff/Decoders/WindowDecoder.cs
+++ b/src/VCDiff/Decoders/WindowDecoder.cs
@@ -12,7 +12,7 @@ namespace VCDiff.Decoders
          */
         public const int DefaultMaxTargetFileSize = 67108864;  // 64 MB
 
-        private int  maxWindowSize = DefaultMaxTargetFileSize;
+        private int maxWindowSize;
 
         private IByteBuffer buffer;
         private int returnCode;
@@ -69,9 +69,13 @@ namespace VCDiff.Decoders
             chunk = new ParseableChunk(buffer.Position, buffer.Length);
 
             if (maxWindowSize < 0)
+            {
                 throw new ArgumentException("maxWindowSize must be a positive value", "maxWindowSize");
+            }
             else
+            {
                 this.maxWindowSize = maxWindowSize;
+            }
 
             returnCode = (int)VCDiffResult.SUCCESS;
         }

--- a/src/VCDiff/Decoders/WindowDecoder.cs
+++ b/src/VCDiff/Decoders/WindowDecoder.cs
@@ -6,7 +6,13 @@ namespace VCDiff.Decoders
 {
     internal class WindowDecoder
     {
-        private const uint HardMaxWindowSize = 1u << 24;
+
+        /**
+         * The default maximum target file size (and target window size) 
+         */
+        public const int DefaultMaxTargetFileSize = 67108864;  // 64 MB
+
+        private int  maxWindowSize = DefaultMaxTargetFileSize;
 
         private IByteBuffer buffer;
         private int returnCode;
@@ -55,11 +61,18 @@ namespace VCDiff.Decoders
         /// </summary>
         /// <param name="dictionarySize">the dictionary size</param>
         /// <param name="buffer">the buffer containing the incoming data</param>
-        public WindowDecoder(long dictionarySize, IByteBuffer buffer)
+        /// <param name="maxWindowSize">The maximum target window size in bytes</param>
+        public WindowDecoder(long dictionarySize, IByteBuffer buffer, int maxWindowSize = DefaultMaxTargetFileSize)
         {
             this.dictionarySize = dictionarySize;
             this.buffer = buffer;
             chunk = new ParseableChunk(buffer.Position, buffer.Length);
+
+            if (maxWindowSize < 0)
+                throw new ArgumentException("maxWindowSize must be a positive value", "maxWindowSize");
+            else
+                this.maxWindowSize = maxWindowSize;
+
             returnCode = (int)VCDiffResult.SUCCESS;
         }
 
@@ -303,10 +316,11 @@ namespace VCDiff.Decoders
             }
 
             targetWindowLength = outTargetLength;
-            if (targetWindowLength > HardMaxWindowSize)
+            if (targetWindowLength > maxWindowSize)
             {
                 targetWindowLength = 0;
                 this.returnCode = (int)VCDiffResult.ERROR;
+                throw new InvalidOperationException(String.Format("Length of target window ({0}) exceeds limit of {1} bytes", outTargetLength, maxWindowSize));
             }
             return true;
         }

--- a/src/VCDiff/Decoders/WindowDecoder.cs
+++ b/src/VCDiff/Decoders/WindowDecoder.cs
@@ -62,7 +62,7 @@ namespace VCDiff.Decoders
         /// <param name="dictionarySize">the dictionary size</param>
         /// <param name="buffer">the buffer containing the incoming data</param>
         /// <param name="maxWindowSize">The maximum target window size in bytes</param>
-        public WindowDecoder(long dictionarySize, IByteBuffer buffer, int maxWindowSize = DefaultMaxTargetFileSize)
+        public WindowDecoder(long dictionarySize, IByteBuffer buffer, int maxWindowSize = WindowDecoder.DefaultMaxTargetFileSize)
         {
             this.dictionarySize = dictionarySize;
             this.buffer = buffer;

--- a/src/VCDiff/VCDiff.xml
+++ b/src/VCDiff/VCDiff.xml
@@ -68,13 +68,14 @@
             If the decoder has been initialized.
             </summary>
         </member>
-        <member name="M:VCDiff.Decoders.VcDecoder.#ctor(System.IO.Stream,System.IO.Stream,System.IO.Stream)">
+        <member name="M:VCDiff.Decoders.VcDecoder.#ctor(System.IO.Stream,System.IO.Stream,System.IO.Stream,System.Int32)">
             <summary>
             Creates a new VCDIFF decoder.
             </summary>
             <param name="source">The dictionary stream, or the base file.</param>
             <param name="delta">The stream containing the VCDIFF delta.</param>
             <param name="outputStream">The stream to write the output in.</param>
+            <param name="maxTargetFileSize">The maximum target file size (and target window size) in bytes</param>
         </member>
         <member name="M:VCDiff.Decoders.VcDecoder.Initialize">
             <summary>
@@ -104,12 +105,16 @@
             Disposes the decoder
             </summary>
         </member>
-        <member name="M:VCDiff.Decoders.WindowDecoder.#ctor(System.Int64,VCDiff.Shared.IByteBuffer)">
+        <member name="F:VCDiff.Decoders.WindowDecoder.DefaultMaxTargetFileSize">
+            The default maximum target file size (and target window size) 
+        </member>
+        <member name="M:VCDiff.Decoders.WindowDecoder.#ctor(System.Int64,VCDiff.Shared.IByteBuffer,System.Int32)">
             <summary>
             Parses the window from the data
             </summary>
             <param name="dictionarySize">the dictionary size</param>
             <param name="buffer">the buffer containing the incoming data</param>
+            <param name="maxWindowSize">The maximum target window size in bytes</param>
         </member>
         <member name="M:VCDiff.Decoders.WindowDecoder.Decode(System.Boolean)">
             <summary>


### PR DESCRIPTION
Hello,

I had a problem when applying a diff on big files (more than 300 MB).   
The `Decode` method return "ERROR" for an unknown reason.

I found why : There was a Hard Limit in `WindowDecoder` at 16 MB.

So I added an optionnal parameter in `Decode` method to change this value if needed.

I also set the default value to 64 MB, like others VcDiff implementations.

* https://github.com/google/open-vcdiff/blob/868f459a8d815125c2457f8c74b12493853100f9/src/vcdecoder.cc#L327
* https://github.com/ehrmann/vcdiff-java/blob/ea2dd61963dddbf453bd7018c9aa04666bcadca4/core/src/main/java/com/davidehrmann/vcdiff/engine/VCDiffStreamingDecoderImpl.java#L53

