### PR TITLE
fix a bug with incomplete instruction decoding

### DIFF
--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -211,7 +211,7 @@ namespace VCDiff.Decoders
 
             VCDiffResult result = VCDiffResult.SUCCESS;
 
-            while (this.TotalBytesDecoded < window.TargetWindowLength && instructionBuffer.CanRead)
+            while (this.TotalBytesDecoded < window.TargetWindowLength)
             {
                 VCDiffInstructionType instruction = instrDecoder.Next(out int decodedSize, out byte mode);
 


### PR DESCRIPTION
In the case of last instruction in the stream with a pending part final `instrDecoder.Next` is not called