### PR TITLE
Additional Perf. Optimizations

### DIFF
--- a/src/VCDiff.Benchmark/Program.cs
+++ b/src/VCDiff.Benchmark/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+
+namespace VCDiff.Benchmark
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<RandomDataDecode>();
+            BenchmarkRunner.Run<RandomDataEncode>();
+        }
+    }
+}

--- a/src/VCDiff.Benchmark/RandomDataDecode.cs
+++ b/src/VCDiff.Benchmark/RandomDataDecode.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using VCDiff.Decoders;
+using VCDiff.Encoders;
+
+namespace VCDiff.Benchmark
+{
+    [SimpleJob(1, 3, 8)]
+    public class RandomDataDecode
+    {
+        [Params(//1 * 1024 * 256,  // 0.25MiB
+            //1 * 1024 * 1024, // 2 MiB
+            16 * 1024 * 1024 // 16 MiB
+        )]
+        public int Bytes { get; set; }
+
+        [Params(32)] // AVX Only
+        //[Params(16, 32)] // AVX vs SSE
+        public int BlockSize { get; set; }
+
+        private const int RepeatCount = 128;
+        private byte[] _data;
+        private Stream _patchSlightModified;
+        private Stream _patchHeavyModified;
+
+        private Stream _sourceStream;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _data = RandomDataGenerator.GetRandomBytes(Bytes);
+            RandomDataEncode.MakeRandomData(_data, out var dataSlightModified, out var dataHeavyModified);
+
+            // Make Source Stream
+            _sourceStream = new MemoryStream(_data);
+
+            // Make Slightly Mod Patch
+            CreatePatch(dataSlightModified, ref _patchSlightModified);
+            CreatePatch(dataHeavyModified, ref _patchHeavyModified);
+        }
+
+        private void CreatePatch(byte[] targetData, ref Stream receiver)
+        {
+            _sourceStream.Seek(0, SeekOrigin.Begin);
+            receiver = new MemoryStream(_data.Length);
+            using var targetStream = new MemoryStream(targetData);
+            using var encoder = new VcEncoder(_sourceStream, targetStream, receiver, 1, BlockSize);
+            encoder.Encode();
+        }
+        
+        [Benchmark]
+        public void DecodeSlightlyModified()
+        {
+            using var result = new MemoryStream((int)_sourceStream.Length);
+            for (int x = 0; x < RepeatCount; x++)
+            {
+                _sourceStream.Seek(0, SeekOrigin.Begin);
+                _patchSlightModified.Seek(0, SeekOrigin.Begin);
+                result.Position = 0;
+                using var decoder = new VcDecoder(_sourceStream, _patchSlightModified, result, int.MaxValue);
+                decoder.Decode(out long written);
+            }
+        }
+
+        [Benchmark]
+        public void DecodeHeavilyModified()
+        {
+            using var result = new MemoryStream((int)_sourceStream.Length);
+            for (int x = 0; x < RepeatCount; x++)
+            {
+                _sourceStream.Seek(0, SeekOrigin.Begin);
+                _patchHeavyModified.Seek(0, SeekOrigin.Begin);
+                result.Position = 0;
+                using var decoder = new VcDecoder(_sourceStream, _patchHeavyModified, result, int.MaxValue);
+                decoder.Decode(out long written);
+            }
+        }
+    }
+}

--- a/src/VCDiff.Benchmark/RandomDataDecode.cs
+++ b/src/VCDiff.Benchmark/RandomDataDecode.cs
@@ -10,6 +10,7 @@ using VCDiff.Encoders;
 
 namespace VCDiff.Benchmark
 {
+    [MemoryDiagnoser()]
     [SimpleJob(1, 3, 8)]
     public class RandomDataDecode
     {

--- a/src/VCDiff.Benchmark/RandomDataEncode.cs
+++ b/src/VCDiff.Benchmark/RandomDataEncode.cs
@@ -5,6 +5,7 @@ using VCDiff.Encoders;
 
 namespace VCDiff.Benchmark
 {
+    [MemoryDiagnoser()]
     [SimpleJob(1, 3, 8)]
     public class RandomDataEncode
     {

--- a/src/VCDiff.Benchmark/RandomDataEncode.cs
+++ b/src/VCDiff.Benchmark/RandomDataEncode.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using VCDiff.Encoders;
+
+namespace VCDiff.Benchmark
+{
+    [SimpleJob(1, 3, 8)]
+    public class RandomDataEncode
+    {
+        [Params(//1 * 1024 * 256,  // 0.25MiB
+                //1 * 1024 * 1024, // 2 MiB
+                16 * 1024 * 1024 // 16 MiB
+                )]
+        public int Bytes { get; set; }
+
+        [Params(32)] // AVX Only
+        //[Params(16, 32)] // AVX vs SSE
+        public int BlockSize { get; set; }
+
+        private byte[] _data;
+        private byte[] _dataSlightModified;
+        private byte[] _dataHeavyModified;
+
+        private Stream _sourceStream;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _data = RandomDataGenerator.GetRandomBytes(Bytes);
+            MakeRandomData(_data, out _dataSlightModified, out _dataHeavyModified);
+            _sourceStream = new MemoryStream(_data);
+        }
+
+        [IterationSetup]
+        public void IterationSetup() => _sourceStream.Seek(0, SeekOrigin.Begin);
+
+        [Benchmark]
+        public void EncodeSlightlyModified()
+        {
+            using var targetStream = new MemoryStream(_dataSlightModified);
+            using var patchStream  = new MemoryStream(_data.Length);
+
+            using var encoder = new VcEncoder(_sourceStream, targetStream, patchStream, 1, BlockSize);
+            encoder.Encode();
+        }
+
+        [Benchmark]
+        public void EncodeHeavilyModified()
+        {
+            using var targetStream = new MemoryStream(_dataHeavyModified);
+            using var patchStream  = new MemoryStream(_data.Length);
+
+            using var encoder = new VcEncoder(_sourceStream, targetStream, patchStream, 1, BlockSize);
+            encoder.Encode();
+        }
+
+
+        // Utility Methods
+        public static void MakeRandomData(byte[] data, out byte[] dataSlightModified, out byte[] dataHeavyModified)
+        {
+            dataSlightModified = (byte[])data.Clone();
+            dataHeavyModified = (byte[])data.Clone();
+
+            var random = new Random(data.Length);
+            for (int x = 0; x < dataHeavyModified.Length; x++)
+            {
+                var next = random.Next(0, 1000);
+                if (next >= 250) // 3 / 4 chance.
+                    dataHeavyModified[x] += (byte)next;
+                if (next >= 995) // 1 / 200 chance.
+                    dataSlightModified[x] += (byte)next;
+            }
+        }
+    }
+}

--- a/src/VCDiff.Benchmark/RandomDataGenerator.cs
+++ b/src/VCDiff.Benchmark/RandomDataGenerator.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace VCDiff.Benchmark
+{
+    /// <summary>
+    /// Generates random data.
+    /// </summary>
+    public static class RandomDataGenerator
+    {
+        public static byte[] GetRandomBytes(int size)
+        {
+            var data = new byte[size];
+            var random = new Random(size);
+            for (int x = 0; x < data.Length; x++)
+                data[x] = (byte)random.Next();
+
+            return data;
+        }
+    }
+}

--- a/src/VCDiff.Benchmark/VCDiff.Benchmark.csproj
+++ b/src/VCDiff.Benchmark/VCDiff.Benchmark.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VCDiff\VCDiff.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/VCDiff.Tests/FileDiffTests.cs
+++ b/src/VCDiff.Tests/FileDiffTests.cs
@@ -522,17 +522,15 @@ namespace VCDiff.Tests
             long bytesWritten = 0;
 
             using VcDecoder decoder = new VcDecoder(srcStream, deltaStream, outputStream, -1);
-            ArgumentException ex = Assert.Throws<ArgumentException>(() => decoder.Decode(out bytesWritten));
-            Assert.Matches(@"maxWindowSize must be a positive value", ex.Message);
+            Assert.Throws<AggregateException>(() => decoder.Decode(out bytesWritten));
 
             srcStream.Position = 0;
             targetStream.Position = 0;
             deltaStream.Position = 0;
 
-            using VcDecoder decoder1 = new VcDecoder(srcStream, deltaStream, outputStream, 2);
-            InvalidOperationException ex1 = Assert.Throws<InvalidOperationException>(() => decoder1.Decode(out bytesWritten));
-            Assert.Matches(@"Length of target window \(\d*\) exceeds limit of 2 bytes", ex1.Message);
-            
+            using VcDecoder decoder1 = new VcDecoder(srcStream, deltaStream, outputStream, 2); 
+            Assert.Throws<AggregateException>(() => decoder1.Decode(out bytesWritten));
+
 
         }
     }

--- a/src/VCDiff.Tests/FileDiffTests.cs
+++ b/src/VCDiff.Tests/FileDiffTests.cs
@@ -522,16 +522,14 @@ namespace VCDiff.Tests
             long bytesWritten = 0;
 
             using VcDecoder decoder = new VcDecoder(srcStream, deltaStream, outputStream, -1);
-            Assert.Throws<AggregateException>(() => decoder.Decode(out bytesWritten));
+            Assert.Throws<ArgumentException>(() => decoder.Decode(out bytesWritten));
 
             srcStream.Position = 0;
             targetStream.Position = 0;
             deltaStream.Position = 0;
 
             using VcDecoder decoder1 = new VcDecoder(srcStream, deltaStream, outputStream, 2); 
-            Assert.Throws<AggregateException>(() => decoder1.Decode(out bytesWritten));
-
-
+            Assert.Throws<InvalidOperationException>(() => decoder1.Decode(out bytesWritten));
         }
     }
 }

--- a/src/VCDiff.sln
+++ b/src/VCDiff.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 16.0.29721.120
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VCDiff", "VCDiff\VCDiff.csproj", "{4D676F4E-E66D-4A41-861F-600F0FFCD052}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VCDiff.Tests", "VCDiff.Tests\VCDiff.Tests.csproj", "{724A8CFC-F566-47BB-ABE7-2A7DF5EC4E66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VCDiff.Tests", "VCDiff.Tests\VCDiff.Tests.csproj", "{724A8CFC-F566-47BB-ABE7-2A7DF5EC4E66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VCDiff.Benchmark", "VCDiff.Benchmark\VCDiff.Benchmark.csproj", "{29FF95D4-B9BF-480B-B0F1-E5A0BAEAAA82}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{724A8CFC-F566-47BB-ABE7-2A7DF5EC4E66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{724A8CFC-F566-47BB-ABE7-2A7DF5EC4E66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{724A8CFC-F566-47BB-ABE7-2A7DF5EC4E66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29FF95D4-B9BF-480B-B0F1-E5A0BAEAAA82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29FF95D4-B9BF-480B-B0F1-E5A0BAEAAA82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29FF95D4-B9BF-480B-B0F1-E5A0BAEAAA82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29FF95D4-B9BF-480B-B0F1-E5A0BAEAAA82}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -179,13 +179,13 @@ namespace VCDiff.Decoders
         /// Decode if as expecting interleave
         /// </summary>
         /// <returns></returns>
-        public VCDiffResult DecodeInterleave()
+        public Task<VCDiffResult> DecodeInterleave()
         {
             var result = DecodeInterleaveCore();
             targetData.Seek(0, SeekOrigin.Begin);
             targetData.CopyTo(outputStream);
             targetData.SetLength(0);
-            return result;
+            return Task.FromResult(result);
         }
 
         /// <summary>
@@ -272,13 +272,13 @@ namespace VCDiff.Decoders
         /// Decode normally
         /// </summary>
         /// <returns></returns>
-        public VCDiffResult Decode()
+        public Task<VCDiffResult> Decode()
         {
             var result = this.DecodeCore();
             targetData.Seek(0, SeekOrigin.Begin);
             targetData.CopyTo(outputStream);
             targetData.SetLength(0);
-            return result;
+            return Task.FromResult(result);
         }
 
         /// <summary>

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -64,7 +64,7 @@ namespace VCDiff.Decoders
 
                 //try to read in all interleaved bytes
                 //if not then it will buffer for next time
-                previous.Write(delta.ReadBytes((int)interleaveLength).Span);
+                previous.Write(delta.ReadBytesAsSpan((int)interleaveLength));
                 using ByteBuffer incoming = new ByteBuffer(previous.ToArray());
                 previous.SetLength(0);
                 long initialLength = incoming.Length;
@@ -112,7 +112,7 @@ namespace VCDiff.Decoders
 
                         if (initialLength - incoming.Position > 0)
                         {
-                            previous.Write(incoming.ReadBytes((int)(initialLength - incoming.Position)).Span);
+                            previous.Write(incoming.ReadBytesAsSpan((int)(initialLength - incoming.Position)));
                         }
 
                         break;
@@ -145,7 +145,7 @@ namespace VCDiff.Decoders
 
                         if (initialLength - incoming.Position > 0)
                         {
-                            previous.Write(incoming.ReadBytes((int)(initialLength - incoming.Position)).Span);
+                            previous.Write(incoming.ReadBytesAsSpan((int)(initialLength - incoming.Position)));
                         }
 
                         break;
@@ -164,7 +164,7 @@ namespace VCDiff.Decoders
 
             if (window.ChecksumFormat == ChecksumFormat.SDCH)
             {
-                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length));
+                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length).Span);
 
                 if (adler != window.Checksum)
                 {
@@ -248,7 +248,7 @@ namespace VCDiff.Decoders
 
             if (window.ChecksumFormat == ChecksumFormat.SDCH)
             {
-                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length));
+                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length).Span);
 
                 if (adler != window.Checksum)
                 {
@@ -257,7 +257,7 @@ namespace VCDiff.Decoders
             }
             else if (window.ChecksumFormat == ChecksumFormat.Xdelta3)
             {
-                uint adler = Checksum.ComputeXdelta3Adler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length));
+                uint adler = Checksum.ComputeXdelta3Adler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length).Span);
 
                 if (adler != window.Checksum)
                 {
@@ -318,9 +318,7 @@ namespace VCDiff.Decoders
             if (decodedAddress + size <= window.SourceSegmentLength)
             {
                 source.Position = decodedAddress + window.SourceSegmentOffset;
-                var rbytes = source.ReadBytes(size).Span;
-                //outputStream.Write(rbytes);
-                targetData.Write(rbytes);
+                targetData.Write(source.ReadBytesAsSpan(size));
                 this.TotalBytesDecoded += size;
                 return VCDiffResult.SUCCESS;
             }
@@ -331,9 +329,7 @@ namespace VCDiff.Decoders
                 // ... plus some data from source segment
                 long partialCopySize = window.SourceSegmentLength - decodedAddress;
                 source.Position = decodedAddress + +window.SourceSegmentOffset;
-                var rbytes = source.ReadBytes((int)partialCopySize).Span;
-                //outputStream.Write(rbytes);
-                targetData.Write(rbytes);
+                targetData.Write(source.ReadBytesAsSpan((int)partialCopySize));
                 this.TotalBytesDecoded += partialCopySize;
                 decodedAddress += partialCopySize;
                 size -= (int)partialCopySize;
@@ -400,10 +396,8 @@ namespace VCDiff.Decoders
             {
                 return VCDiffResult.EOD;
             }
-
-            var rbytes = addRun.ReadBytes(size).Span;
-            //outputStream.Write(rbytes);
-            targetData.Write(rbytes);
+            
+            targetData.Write(addRun.ReadBytesAsSpan(size));
             TotalBytesDecoded += size;
             return VCDiffResult.SUCCESS;
         }

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -206,9 +206,9 @@ namespace VCDiff.Decoders
 
         private VCDiffResult DecodeCore()
         {
-            using ByteBuffer instructionBuffer = new ByteBuffer(window.InstructionsAndSizesData);
-            using ByteBuffer addressBuffer = new ByteBuffer(window.AddressesForCopyData);
-            using ByteBuffer addRunBuffer = new ByteBuffer(window.AddRunData);
+            using ByteBuffer instructionBuffer = new ByteBuffer(window.InstructionsAndSizesData.AsSpanOrDefault());
+            using ByteBuffer addressBuffer = new ByteBuffer(window.AddressesForCopyData.AsSpanOrDefault());
+            using ByteBuffer addRunBuffer = new ByteBuffer(window.AddRunData.AsSpanOrDefault());
 
             InstructionDecoder instrDecoder = new InstructionDecoder(instructionBuffer, customTable);
 

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -7,12 +7,15 @@ using VCDiff.Shared;
 
 namespace VCDiff.Decoders
 {
-    internal class BodyDecoder : IDisposable
+    internal class BodyDecoder<TWindowDecoderByteBuffer, TSourceBuffer, TDeltaBuffer> : IDisposable 
+        where TWindowDecoderByteBuffer : IByteBuffer
+        where TSourceBuffer : IByteBuffer
+        where TDeltaBuffer : IByteBuffer
     {
-        private WindowDecoder window;
+        private WindowDecoder<TWindowDecoderByteBuffer> window;
         private Stream outputStream;
-        private IByteBuffer source;
-        private IByteBuffer delta;
+        private TSourceBuffer source;
+        private TDeltaBuffer delta;
         private AddressCache addressCache;
         private MemoryStream targetData;
         private CustomCodeTableDecoder? customTable;
@@ -28,7 +31,7 @@ namespace VCDiff.Decoders
         /// <param name="delta">The delta</param>
         /// <param name="decodedTarget">the out stream</param>
         /// <param name="customTable">custom table if any. Default is null.</param>
-        public BodyDecoder(WindowDecoder w, IByteBuffer source, IByteBuffer delta, Stream decodedTarget, CustomCodeTableDecoder? customTable = null)
+        public BodyDecoder(WindowDecoder<TWindowDecoderByteBuffer> w, TSourceBuffer source, TDeltaBuffer delta, Stream decodedTarget, CustomCodeTableDecoder? customTable = null)
         {
             if (customTable != null)
             {

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -179,13 +179,13 @@ namespace VCDiff.Decoders
         /// Decode if as expecting interleave
         /// </summary>
         /// <returns></returns>
-        public Task<VCDiffResult> DecodeInterleave()
+        public VCDiffResult DecodeInterleave()
         {
             var result = DecodeInterleaveCore();
             targetData.Seek(0, SeekOrigin.Begin);
             targetData.CopyTo(outputStream);
             targetData.SetLength(0);
-            return Task.FromResult(result);
+            return result;
         }
 
         /// <summary>
@@ -272,13 +272,13 @@ namespace VCDiff.Decoders
         /// Decode normally
         /// </summary>
         /// <returns></returns>
-        public Task<VCDiffResult> Decode()
+        public VCDiffResult Decode()
         {
             var result = this.DecodeCore();
             targetData.Seek(0, SeekOrigin.Begin);
             targetData.CopyTo(outputStream);
             targetData.SetLength(0);
-            return Task.FromResult(result);
+            return result;
         }
 
         /// <summary>

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -317,7 +317,7 @@ namespace VCDiff.Decoders
             // Copy all data from source segment
             if (decodedAddress + size <= window.SourceSegmentLength)
             {
-                source.Position = decodedAddress + window.SourceSegmentOffset;
+                source.Position = (int)(decodedAddress + window.SourceSegmentOffset);
                 targetData.Write(source.ReadBytesAsSpan(size));
                 this.TotalBytesDecoded += size;
                 return VCDiffResult.SUCCESS;
@@ -328,7 +328,7 @@ namespace VCDiff.Decoders
             {
                 // ... plus some data from source segment
                 long partialCopySize = window.SourceSegmentLength - decodedAddress;
-                source.Position = decodedAddress + +window.SourceSegmentOffset;
+                source.Position = (int)(decodedAddress + +window.SourceSegmentOffset);
                 targetData.Write(source.ReadBytesAsSpan((int)partialCopySize));
                 this.TotalBytesDecoded += partialCopySize;
                 decodedAddress += partialCopySize;

--- a/src/VCDiff/Decoders/BodyDecoder.cs
+++ b/src/VCDiff/Decoders/BodyDecoder.cs
@@ -164,7 +164,7 @@ namespace VCDiff.Decoders
 
             if (window.ChecksumFormat == ChecksumFormat.SDCH)
             {
-                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length).Span);
+                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsSpan(0, (int)targetData.Length));
 
                 if (adler != window.Checksum)
                 {
@@ -248,7 +248,7 @@ namespace VCDiff.Decoders
 
             if (window.ChecksumFormat == ChecksumFormat.SDCH)
             {
-                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length).Span);
+                uint adler = Checksum.ComputeGoogleAdler32(targetData.GetBuffer().AsSpan(0, (int)targetData.Length));
 
                 if (adler != window.Checksum)
                 {
@@ -257,7 +257,7 @@ namespace VCDiff.Decoders
             }
             else if (window.ChecksumFormat == ChecksumFormat.Xdelta3)
             {
-                uint adler = Checksum.ComputeXdelta3Adler32(targetData.GetBuffer().AsMemory(0, (int)targetData.Length).Span);
+                uint adler = Checksum.ComputeXdelta3Adler32(targetData.GetBuffer().AsSpan(0, (int)targetData.Length));
 
                 if (adler != window.Checksum)
                 {

--- a/src/VCDiff/Decoders/CustomCodeTableDecoder.cs
+++ b/src/VCDiff/Decoders/CustomCodeTableDecoder.cs
@@ -21,7 +21,7 @@ namespace VCDiff.Decoders
 
             if (lengthOfCodeTable == 0) return VCDiffResult.ERROR;
 
-            using ByteBuffer codeTable = new ByteBuffer(source.ReadBytes(lengthOfCodeTable));
+            using ByteBuffer codeTable = new ByteBuffer(source.ReadBytes(lengthOfCodeTable).ToArray());
 
             //according to the RFC specifications the next two items will be the size of near and size of same
             //they are bytes in the RFC spec, but for some reason Google uses the varint to read which does

--- a/src/VCDiff/Decoders/CustomCodeTableDecoder.cs
+++ b/src/VCDiff/Decoders/CustomCodeTableDecoder.cs
@@ -42,7 +42,7 @@ namespace VCDiff.Decoders
             //Decode the code table VCDiff file itself
             //stream the decoded output into a memory stream
             using MemoryStream sout = new MemoryStream();
-            VcDecoder decoder = new VcDecoder(dictionary, codeTable, sout);
+            var decoder = new VcDecoderEx<ByteBuffer, ByteBuffer>(dictionary, codeTable, sout);
             var result = decoder.Decode(out long bytesWritten);
 
             if (result != VCDiffResult.SUCCESS || bytesWritten == 0)

--- a/src/VCDiff/Decoders/InstructionDecoder.cs
+++ b/src/VCDiff/Decoders/InstructionDecoder.cs
@@ -27,7 +27,7 @@ namespace VCDiff.Decoders
         /// <param name="size">the size</param>
         /// <param name="mode">the mode</param>
         /// <returns></returns>
-        public VCDiffInstructionType Next(out int size, out byte mode)
+        public unsafe VCDiffInstructionType Next(out int size, out byte mode)
         {
             byte opcode = 0;
             byte instructionType = CodeTable.N;
@@ -40,9 +40,9 @@ namespace VCDiff.Decoders
                 {
                     opcode = (byte)pendingSecond;
                     pendingSecond = CodeTable.kNoOpcode;
-                    instructionType = table.inst2.Span[opcode];
-                    instructionSize = table.size2.Span[opcode];
-                    instructionMode = table.mode2.Span[opcode];
+                    instructionType = table.inst2.Pointer[opcode];
+                    instructionSize = table.size2.Pointer[opcode];
+                    instructionMode = table.mode2.Pointer[opcode];
                     break;
                 }
 
@@ -54,14 +54,14 @@ namespace VCDiff.Decoders
                 }
 
                 opcode = source.PeekByte();
-                if (table.inst2.Span[opcode] != CodeTable.N)
+                if (table.inst2.Pointer[opcode] != CodeTable.N)
                 {
                     pendingSecond = source.PeekByte();
                 }
                 source.Next();
-                instructionType = table.inst1.Span[opcode];
-                instructionSize = table.size1.Span[opcode];
-                instructionMode = table.mode1.Span[opcode];
+                instructionType = table.inst1.Pointer[opcode];
+                instructionSize = table.size1.Pointer[opcode];
+                instructionMode = table.mode1.Pointer[opcode];
             } while (instructionType == CodeTable.N);
 
             if (instructionSize == 0)

--- a/src/VCDiff/Decoders/VcDecoder.cs
+++ b/src/VCDiff/Decoders/VcDecoder.cs
@@ -130,7 +130,7 @@ namespace VCDiff.Decoders
                 
                 int headerLength = VarIntBE.ParseInt32(delta);
                 // skip the app header
-                delta.ReadBytes(headerLength);
+                delta.ReadBytesAsSpan(headerLength);
             }
 
 

--- a/src/VCDiff/Decoders/VcDecoderEx.cs
+++ b/src/VCDiff/Decoders/VcDecoderEx.cs
@@ -13,6 +13,9 @@ namespace VCDiff.Decoders
     /// </summary>
     public class VcDecoder : VcDecoderEx<ByteStreamReader, ByteStreamReader>, IDisposable
     {
+        private bool _ownsSources;
+        private bool _disposed;
+
         /// <summary>
         /// Creates a new VCDIFF decoder.
         /// </summary>
@@ -27,6 +30,21 @@ namespace VCDiff.Decoders
             base.outputStream      = outputStream;
             base.maxTargetFileSize = maxTargetFileSize;
             base.IsInitialized     = false;
+            _ownsSources = true;
+        }
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (_ownsSources && !_disposed)
+            {
+                base.delta.Dispose();
+                base.source.Dispose();
+                _disposed = true;
+            }
+
+            GC.SuppressFinalize(this);
         }
     }
 
@@ -302,10 +320,6 @@ namespace VCDiff.Decoders
         /// <summary>
         /// Disposes the decoder
         /// </summary>
-        public void Dispose()
-        {
-            delta?.Dispose();
-            source?.Dispose();
-        }
+        public virtual void Dispose() { }
     }
 }

--- a/src/VCDiff/Decoders/VcDecoderEx.cs
+++ b/src/VCDiff/Decoders/VcDecoderEx.cs
@@ -191,7 +191,7 @@ namespace VCDiff.Decoders
             while (delta.CanRead)
             {
                 //delta is streamed in order aka not random access
-                var w = new WindowDecoder<TDeltaBuffer>(source.Length, delta, maxTargetFileSize);
+                using var w = new WindowDecoder<TDeltaBuffer>(source.Length, delta, maxTargetFileSize);
 
                 if (!w.Decode(this.IsSDCHFormat))
                     return (VCDiffResult)w.Result;
@@ -246,7 +246,7 @@ namespace VCDiff.Decoders
             while (delta.CanRead)
             {
                 //delta is streamed in order aka not random access
-                var w = new WindowDecoder<TDeltaBuffer>(source.Length, delta, maxTargetFileSize);
+                using var w = new WindowDecoder<TDeltaBuffer>(source.Length, delta, maxTargetFileSize);
 
                 if (w.Decode(this.IsSDCHFormat))
                 {

--- a/src/VCDiff/Decoders/WindowDecoder.cs
+++ b/src/VCDiff/Decoders/WindowDecoder.cs
@@ -27,7 +27,7 @@ namespace VCDiff.Decoders
         private byte winIndicator;
         private long sourceSegmentLength;
         private long sourceSegmentOffset;
-        private long targetLength;
+        private long _targetLength;
         private long addRunLength;
         private long instructionAndSizesLength;
         private long addressForCopyLength;
@@ -51,7 +51,7 @@ namespace VCDiff.Decoders
 
         public long SourceSegmentLength => sourceSegmentLength;
 
-        public long TargetWindowLength => targetLength;
+        public long TargetWindowLength => _targetLength;
 
         public uint Checksum => checksum;
 
@@ -95,7 +95,7 @@ namespace VCDiff.Decoders
                 return false;
             }
 
-            if (!ParseWindowLengths(out targetLength))
+            if (!ParseWindowLengths(out _targetLength))
             {
                 return false;
             }
@@ -399,7 +399,7 @@ namespace VCDiff.Decoders
             InstructionsAndSizesData.Dispose();
             AddressesForCopyData.Dispose();
         }
-        public class ParseableChunk
+        public struct ParseableChunk
         {
             private long end;
             private long position;

--- a/src/VCDiff/Decoders/WindowDecoder.cs
+++ b/src/VCDiff/Decoders/WindowDecoder.cs
@@ -121,17 +121,18 @@ namespace VCDiff.Decoders
                 return true;
             }
 
+            // Note: Copied required here due to caching behaviour.
             if (buffer.CanRead)
             {
-                AddRunData = buffer.ReadBytes((int)addRunLength);
+                AddRunData = buffer.ReadBytes((int)addRunLength).ToArray();
             }
             if (buffer.CanRead)
             {
-                InstructionsAndSizesData = buffer.ReadBytes((int)instructionAndSizesLength);
+                InstructionsAndSizesData = buffer.ReadBytes((int)instructionAndSizesLength).ToArray();
             }
             if (buffer.CanRead)
             {
-                AddressesForCopyData = buffer.ReadBytes((int)addressForCopyLength);
+                AddressesForCopyData = buffer.ReadBytes((int)addressForCopyLength).ToArray();
             }
 
             return true;

--- a/src/VCDiff/Decoders/WindowDecoder.cs
+++ b/src/VCDiff/Decoders/WindowDecoder.cs
@@ -4,17 +4,19 @@ using VCDiff.Shared;
 
 namespace VCDiff.Decoders
 {
-    internal class WindowDecoder
+    internal class WindowDecoderBase
     {
-
         /**
          * The default maximum target file size (and target window size) 
          */
         public const int DefaultMaxTargetFileSize = 67108864;  // 64 MB
+    }
 
+    internal class WindowDecoder<TByteBuffer> : WindowDecoderBase where TByteBuffer : IByteBuffer
+    {
         private int maxWindowSize;
 
-        private IByteBuffer buffer;
+        private TByteBuffer buffer;
         private int returnCode;
         private long deltaEncodingLength;
         private long deltaEncodingStart;
@@ -62,7 +64,7 @@ namespace VCDiff.Decoders
         /// <param name="dictionarySize">the dictionary size</param>
         /// <param name="buffer">the buffer containing the incoming data</param>
         /// <param name="maxWindowSize">The maximum target window size in bytes</param>
-        public WindowDecoder(long dictionarySize, IByteBuffer buffer, int maxWindowSize = WindowDecoder.DefaultMaxTargetFileSize)
+        public WindowDecoder(long dictionarySize, TByteBuffer buffer, int maxWindowSize = DefaultMaxTargetFileSize)
         {
             this.dictionarySize = dictionarySize;
             this.buffer = buffer;

--- a/src/VCDiff/Encoders/BlockHash.cs
+++ b/src/VCDiff/Encoders/BlockHash.cs
@@ -135,7 +135,7 @@ namespace VCDiff.Encoders
 
             long offset = source.Position + NextIndexToAdd;
             long end = source.Position + endLimit;
-            source.Position = offset;
+            source.Position = (int) offset;
             while (offset < end)
             {
                 unsafe

--- a/src/VCDiff/Encoders/BlockHash.cs
+++ b/src/VCDiff/Encoders/BlockHash.cs
@@ -166,7 +166,10 @@ namespace VCDiff.Encoders
         /// <param name="target">the target buffer</param>
         /// <param name="m">the match object to use</param>
 #if NETCOREAPP3_1 || NET5_0
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
+#if NET5_0
+        [SkipLocalsInit]
 #endif
         public unsafe void FindBestMatch(ulong hash, long candidateStart, long targetStart, long targetSize, byte* targetPtr, ByteBuffer target, ref Match m)
         {
@@ -244,6 +247,9 @@ namespace VCDiff.Encoders
             AddAllBlocksThroughIndex(source.Length);
         }
 
+#if NET5_0
+        [SkipLocalsInit]
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe bool BlockContentsMatch(long block1, long tOffset, byte *sourcePtr, byte *targetPtr, ByteBuffer target)
         {
@@ -310,6 +316,7 @@ namespace VCDiff.Encoders
             return true;
         }
 
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe long FirstMatchingBlock(ulong hash, long toffset, byte* sourcePtr, byte* targetPtr, ByteBuffer target)
         {
@@ -327,7 +334,12 @@ namespace VCDiff.Encoders
             return SkipNonMatchingBlocks(nextBlockTable[blockNumber], toffset, sourcePtr, targetPtr, target);
         }
 
+#if NET5_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+        [SkipLocalsInit]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private unsafe long SkipNonMatchingBlocks(long blockNumber, long toffset, byte* sourcePtr, byte* targetPtr, ByteBuffer target)
         {
             int probes = 0;
@@ -418,6 +430,10 @@ namespace VCDiff.Encoders
 
             return bytesFound;
         }
+#endif
+
+#if NET5_0
+        [SkipLocalsInit]
 #endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe long MatchingBytesToLeft(long start, long tstart, byte* sourcePtr, byte* targetPtr, ByteBuffer target, long maxBytes)
@@ -531,6 +547,9 @@ namespace VCDiff.Encoders
         }
 #endif
 
+#if NET5_0
+        [SkipLocalsInit]
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe long MatchingBytesToRight(long end, long tstart, byte* sourcePtr, byte* targetPtr, ByteBuffer target, long maxBytes)
         {

--- a/src/VCDiff/Encoders/BlockHash.cs
+++ b/src/VCDiff/Encoders/BlockHash.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using VCDiff.Shared;
@@ -56,9 +56,17 @@ namespace VCDiff.Encoders
             this.blocksCount = source.Length / blockSize;
 
             hashTableMask = (ulong)tableSize - 1;
+
+#if NET5_0
+            hashTable = GC.AllocateUninitializedArray<long>((int) tableSize);
+            nextBlockTable = GC.AllocateUninitializedArray<long>((int) blocksCount);
+            lastBlockTable = GC.AllocateUninitializedArray<long>((int) blocksCount);
+#else
             hashTable = new long[tableSize];
             nextBlockTable = new long[blocksCount];
             lastBlockTable = new long[blocksCount];
+#endif
+
             lastBlockAdded = -1;
             SetTablesToInvalid();
         }

--- a/src/VCDiff/Encoders/ChunkEncoder.cs
+++ b/src/VCDiff/Encoders/ChunkEncoder.cs
@@ -151,6 +151,7 @@ namespace VCDiff.Encoders
 
         public void Dispose()
         {
+            dictionary?.Dispose();
             oldData?.Dispose();
             windowEncoder?.Dispose();
             GC.SuppressFinalize(this);

--- a/src/VCDiff/Encoders/ChunkEncoder.cs
+++ b/src/VCDiff/Encoders/ChunkEncoder.cs
@@ -44,7 +44,7 @@ namespace VCDiff.Encoders
         public unsafe void EncodeChunk(ByteBuffer newData, Stream outputStream)
         {
             newData.Position = 0;
-            ReadOnlyMemory<byte> checksumBytes = newData.ReadBytes((int)newData.Length);
+            var checksumBytes = newData.ReadBytesAsSpan((int)newData.Length);
 
             uint checksum = this.checksumFormat switch
             {
@@ -120,7 +120,7 @@ namespace VCDiff.Encoders
             {
                 int len = (int)(newData.Length - nextEncode);
                 newData.Position = nextEncode;
-                windowEncoder.Add(newData.ReadBytes(len).Span);
+                windowEncoder.Add(newData.ReadBytesAsSpan(len));
             }
 
             //output the final window
@@ -144,7 +144,7 @@ namespace VCDiff.Encoders
             if (bestMatch.tOffset > 0)
             {
                 newData.Position = unencodedStart;
-                windowEncoder?.Add(newData.ReadBytes((int)bestMatch.tOffset).Span);
+                windowEncoder?.Add(newData.ReadBytesAsSpan((int)bestMatch.tOffset));
             }
 
             windowEncoder?.Copy((int)bestMatch.sOffset, (int)bestMatch.size);

--- a/src/VCDiff/Encoders/ChunkEncoder.cs
+++ b/src/VCDiff/Encoders/ChunkEncoder.cs
@@ -2,6 +2,10 @@
 using System.IO;
 using VCDiff.Shared;
 
+#if NET5_0
+using System.Runtime.CompilerServices;
+#endif
+
 namespace VCDiff.Encoders
 {
     internal class ChunkEncoder : IDisposable
@@ -116,6 +120,9 @@ namespace VCDiff.Encoders
 
         //currently does not support looking in target
         //only the dictionary
+#if NET5_0
+        [SkipLocalsInit]
+#endif
         private unsafe long EncodeCopyForBestMatch(ulong hash, long candidateStart, long unencodedStart, long unencodedSize, byte* newDataPtr, ByteBuffer newData)
         {
             BlockHash.Match bestMatch = new BlockHash.Match();

--- a/src/VCDiff/Encoders/ChunkEncoder.cs
+++ b/src/VCDiff/Encoders/ChunkEncoder.cs
@@ -40,6 +40,11 @@ namespace VCDiff.Encoders
             this.interleaved = interleaved;
         }
 
+        ~ChunkEncoder()
+        {
+            Dispose();
+        }
+
         /// <summary>
         /// Encodes the data using the settings from initialization
         /// </summary>
@@ -148,6 +153,7 @@ namespace VCDiff.Encoders
         {
             oldData?.Dispose();
             windowEncoder?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/VCDiff/Encoders/ChunkEncoder.cs
+++ b/src/VCDiff/Encoders/ChunkEncoder.cs
@@ -152,7 +152,6 @@ namespace VCDiff.Encoders
         public void Dispose()
         {
             dictionary?.Dispose();
-            oldData?.Dispose();
             windowEncoder?.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/VCDiff/Encoders/InstructionMap.cs
+++ b/src/VCDiff/Encoders/InstructionMap.cs
@@ -75,7 +75,7 @@ namespace VCDiff.Encoders
             return maxSize;
         }
 
-        private class OpcodeMap2
+        private struct OpcodeMap2
         {
             private int[][][] opcodes2;
             private int maxSize;
@@ -134,7 +134,7 @@ namespace VCDiff.Encoders
             }
         }
 
-        private class OpcodeMap
+        private struct OpcodeMap
         {
             private int[] opcodes;
             private int maxSize;

--- a/src/VCDiff/Encoders/InstructionMap.cs
+++ b/src/VCDiff/Encoders/InstructionMap.cs
@@ -13,39 +13,39 @@ namespace VCDiff.Encoders
         /// <summary>
         /// Instruction mapping for op codes and such for using in encoding
         /// </summary>
-        public InstructionMap()
+        public unsafe InstructionMap()
         {
             table = CodeTable.DefaultTable;
-            var inst2 = table.inst2.Span;
-            var inst1 = table.inst1.Span;
-            var size2 = table.size2.Span;
-            var size1 = table.size1.Span;
-            var mode1 = table.mode1.Span;
-            var mode2 = table.mode2.Span;
+            var inst2 = table.inst2;
+            var inst1 = table.inst1;
+            var size2 = table.size2;
+            var size1 = table.size1;
+            var mode1 = table.mode1;
+            var mode2 = table.mode2;
 
             // max sizes are known for the default code table (18 and 6 respectively).
-            firstMap = new OpcodeMap((int)VCDiffInstructionType.LAST + AddressCache.DefaultLast + 1, FindMaxSize(size1, 18));
-            secondMap = new OpcodeMap2((int)VCDiffInstructionType.LAST + AddressCache.DefaultLast + 1, FindMaxSize(size2, 6));
+            firstMap = new OpcodeMap((int)VCDiffInstructionType.LAST + AddressCache.DefaultLast + 1, FindMaxSize(size1.AsSpan(), 18));
+            secondMap = new OpcodeMap2((int)VCDiffInstructionType.LAST + AddressCache.DefaultLast + 1, FindMaxSize(size2.AsSpan(), 6));
             
             for (int opcode = 0; opcode < CodeTable.kCodeTableSize; ++opcode)
             {
-                if (table.inst2.Span[opcode] == CodeTable.N)
+                if (inst2.Pointer[opcode] == CodeTable.N)
                 {
-                    firstMap.Add(inst1[opcode], size1[opcode], mode1[opcode], (byte)opcode);
+                    firstMap.Add(inst1.Pointer[opcode], size1.Pointer[opcode], mode1.Pointer[opcode], (byte)opcode);
                 }
-                else if (table.inst1.Span[opcode] == CodeTable.N)
+                else if (inst1.Pointer[opcode] == CodeTable.N)
                 {
-                    firstMap.Add(inst1[opcode], size1[opcode], mode1[opcode], (byte)opcode);
+                    firstMap.Add(inst1.Pointer[opcode], size1.Pointer[opcode], mode1.Pointer[opcode], (byte)opcode);
                 }
             }
 
             for (int opcode = 0; opcode < CodeTable.kCodeTableSize; ++opcode)
             {
-                if ((inst1[opcode] != CodeTable.N) && (inst2[opcode] != CodeTable.N))
+                if ((inst1.Pointer[opcode] != CodeTable.N) && (inst2.Pointer[opcode] != CodeTable.N))
                 {
-                    int found = LookFirstOpcode(inst1[opcode], size1[opcode], mode1[opcode]);
+                    int found = LookFirstOpcode(inst1.Pointer[opcode], size1.Pointer[opcode], mode1.Pointer[opcode]);
                     if (found == CodeTable.kNoOpcode) continue;
-                    secondMap.Add((byte)found, inst2[opcode], size2[opcode], mode2[opcode], (byte)opcode);
+                    secondMap.Add((byte)found, inst2.Pointer[opcode], size2.Pointer[opcode], mode2.Pointer[opcode], (byte)opcode);
                 }
             }
         }

--- a/src/VCDiff/Encoders/InstructionMap.cs
+++ b/src/VCDiff/Encoders/InstructionMap.cs
@@ -6,6 +6,8 @@ namespace VCDiff.Encoders
 {
     internal class InstructionMap
     {
+        public static InstructionMap Instance = new InstructionMap();
+
         private CodeTable table;
         private OpcodeMap firstMap;
         private OpcodeMap2 secondMap;

--- a/src/VCDiff/Encoders/RollingHash.cs
+++ b/src/VCDiff/Encoders/RollingHash.cs
@@ -230,6 +230,10 @@ namespace VCDiff.Encoders
         /// <param name="firstByte">the original byte of the data for the first hash</param>
         /// <param name="newByte">the first byte of the new data to hash</param>
         /// <returns></returns>
+#if NET5_0
+        [SkipLocalsInit]
+#endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong UpdateHash(ulong oldHash, byte firstByte, byte newByte)
         {
             // Remove the first byte from the hash

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -166,7 +166,7 @@ namespace VCDiff.Encoders
 
         private async Task<bool> Encode_Init(bool interleaved, ChecksumFormat checksumFormat, WriteMagicHeader writeBytes)
         {
-            if (targetData.Length == 0 || oldData.Length == 0)
+            if (targetData.Length == 0 || oldData!.Length == 0)
                 return false;
 
             oldData.Position = 0;
@@ -190,9 +190,9 @@ namespace VCDiff.Encoders
 
         private void Encode_Setup(bool interleaved, ChecksumFormat checksumFormat, out ChunkEncoder chunkEncoder, out Memory<byte> buf)
         {
-            var dictionary = new BlockHash(oldData, 0, hasher, blockSize);
+            var dictionary = new BlockHash(oldData!, 0, hasher, blockSize);
             dictionary.AddAllBlocks();
-            oldData.Position = 0;
+            oldData!.Position = 0;
 
             chunkEncoder = new ChunkEncoder(dictionary, oldData, hasher, checksumFormat, interleaved, chunkSize);
             buf = new Memory<byte>(new byte[bufferSize]);

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -248,7 +248,6 @@ namespace VCDiff.Encoders
         public void Dispose()
         {
             _nativeAllocation.Dispose();
-            oldData?.Dispose();
             targetData?.Dispose();
             if (this.disposeRollingHash)
                 this.hasher.Dispose();

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -249,6 +249,7 @@ namespace VCDiff.Encoders
         {
             _nativeAllocation.Dispose();
             oldData?.Dispose();
+            targetData?.Dispose();
             if (this.disposeRollingHash)
                 this.hasher.Dispose();
         }

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -95,6 +95,10 @@ namespace VCDiff.Encoders
             if (maxBufferSize <= 0)
                 maxBufferSize = 1;
 
+            this.bufferSize = maxBufferSize * 1024 * 1024;
+            if (target.Length <= maxBufferSize)
+                this.bufferSize = (int) target.Length;
+
             this.blockSize = blockSize;
             this.chunkSize = chunkSize < 2 ? this.blockSize * 2 : chunkSize;
             this.targetData = new ByteStreamReader(target);
@@ -113,7 +117,8 @@ namespace VCDiff.Encoders
             if (this.hasher.WindowSize != this.blockSize)
                 throw new ArgumentException("Supplied RollingHash instance has a different window size than blocksize!");
 
-            this.bufferSize = maxBufferSize * 1024 * 1024;
+            
+
             if (this.blockSize % 2 != 0 || this.chunkSize < 2 || this.chunkSize < 2 * this.blockSize)
                 throw new ArgumentException($"{this.blockSize} can not be less than 2 or twice the blocksize of the dictionary {this.blockSize}.");
         }

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -117,8 +117,6 @@ namespace VCDiff.Encoders
             if (this.hasher.WindowSize != this.blockSize)
                 throw new ArgumentException("Supplied RollingHash instance has a different window size than blocksize!");
 
-            
-
             if (this.blockSize % 2 != 0 || this.chunkSize < 2 || this.chunkSize < 2 * this.blockSize)
                 throw new ArgumentException($"{this.blockSize} can not be less than 2 or twice the blocksize of the dictionary {this.blockSize}.");
         }

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -25,7 +25,7 @@ namespace VCDiff.Encoders
         private int chunkSize;
         private bool disposeRollingHash = false;
 
-        private NativeAllocation _nativeAllocation;
+        private NativeAllocation<byte> _nativeAllocation;
 
         /// <summary>
         /// Creates a new VCDIFF Encoder. The input streams will not be closed once this object is disposed.
@@ -53,7 +53,7 @@ namespace VCDiff.Encoders
         /// <exception cref="ArgumentException">If an invalid blockSize or chunkSize is used..</exception>
         public unsafe VcEncoder(Stream source, Stream target, Stream outputStream, int maxBufferSize = 1, int blockSize = 16, int chunkSize = 0, RollingHash? rollingHash = null)
         {
-            _nativeAllocation = new NativeAllocation((int)source.Length);
+            _nativeAllocation = new NativeAllocation<byte>((int)source.Length);
             source.Read(_nativeAllocation.AsSpan());
             this.oldData = new ByteBuffer(_nativeAllocation.AsSpan());
 

--- a/src/VCDiff/Encoders/VcEncoder.cs
+++ b/src/VCDiff/Encoders/VcEncoder.cs
@@ -148,16 +148,23 @@ namespace VCDiff.Encoders
 
             // Read in all the dictionary it is the only thing that needs to be
             Encode_Setup(interleaved, checksumFormat, out var chunker, out var buf);
-            var bufSpan = buf.Span;
-            while (targetData.CanRead)
+            try
             {
-                int bytesRead = targetData.ReadBytesIntoBuf(bufSpan);
-                using ByteBuffer ntarget = new ByteBuffer(buf[..bytesRead]);
-                chunker.EncodeChunk(ntarget, outputStream);
-                progress?.Report((float)targetData.Position / targetData.Length);
-            }
+                var bufSpan = buf.Span;
+                while (targetData.CanRead)
+                {
+                    int bytesRead = targetData.ReadBytesIntoBuf(bufSpan);
+                    using ByteBuffer ntarget = new ByteBuffer(buf[..bytesRead]);
+                    chunker.EncodeChunk(ntarget, outputStream);
+                    progress?.Report((float)targetData.Position / targetData.Length);
+                }
 
-            return VCDiffResult.SUCCESS;
+                return VCDiffResult.SUCCESS;
+            }
+            finally
+            {
+                chunker.Dispose();
+            }
         }
 
         /// <summary>
@@ -183,15 +190,22 @@ namespace VCDiff.Encoders
 
             //read in all the dictionary it is the only thing that needs to be
             Encode_Setup(interleaved, checksumFormat, out var chunker, out var buf);
-            while (targetData.CanRead)
+            try
             {
-                int read = await targetData.ReadBytesIntoBufAsync(buf);
-                using ByteBuffer ntarget = new ByteBuffer(buf[..read]);
-                chunker.EncodeChunk(ntarget, outputStream);
-                progress?.Report((float) targetData.Position / targetData.Length);
-            }
+                while (targetData.CanRead)
+                {
+                    int read = await targetData.ReadBytesIntoBufAsync(buf);
+                    using ByteBuffer ntarget = new ByteBuffer(buf[..read]);
+                    chunker.EncodeChunk(ntarget, outputStream);
+                    progress?.Report((float)targetData.Position / targetData.Length);
+                }
 
-            return VCDiffResult.SUCCESS;
+                return VCDiffResult.SUCCESS;
+            }
+            finally
+            {
+                chunker.Dispose();
+            }
         }
 
         private async Task<bool> Encode_Init(bool interleaved, ChecksumFormat checksumFormat, WriteMagicHeader writeBytes)

--- a/src/VCDiff/Encoders/WindowEncoder.cs
+++ b/src/VCDiff/Encoders/WindowEncoder.cs
@@ -248,6 +248,7 @@ namespace VCDiff.Encoders
 
                 outputStream.Write(instructionAndSizes.GetBuffer().AsSpan(0, (int)instructionAndSizes.Length)); //data for instructions and sizes, in interleaved it is everything
             }
+
             //end of delta encoding
 
             long sizeAfterDelta = outputStream.Position;
@@ -262,7 +263,6 @@ namespace VCDiff.Encoders
             {
                 throw new IOException("Empty target window");
             }
-            addrCache = new AddressCache();
         }
 
         public void Dispose()

--- a/src/VCDiff/Encoders/WindowEncoder.cs
+++ b/src/VCDiff/Encoders/WindowEncoder.cs
@@ -42,7 +42,7 @@ namespace VCDiff.Encoders
             addrCache = new AddressCache();
             targetLength = 0;
             lastOpcodeIndex = -1;
-            instrMap = new InstructionMap();
+            instrMap = InstructionMap.Instance;
 
             //Separate buffers for each type if not interleaved
             if (!interleaved)

--- a/src/VCDiff/Encoders/WindowEncoder.cs
+++ b/src/VCDiff/Encoders/WindowEncoder.cs
@@ -118,6 +118,9 @@ namespace VCDiff.Encoders
             targetLength += data.Length;
         }
 
+#if NET5_0
+        [SkipLocalsInit]
+#endif
         public void Copy(int offset, int length)
         {
             byte mode = addrCache.EncodeAddress(offset, dictionarySize + targetLength, out long encodedAddr);

--- a/src/VCDiff/Encoders/WindowEncoder.cs
+++ b/src/VCDiff/Encoders/WindowEncoder.cs
@@ -180,11 +180,6 @@ namespace VCDiff.Encoders
         public void Output(Stream outputStream)
         {
             int lengthOfDelta = CalculateLengthOfTheDeltaEncoding();
-            int windowSize = lengthOfDelta +
-            1 +
-            VarIntBE.CalcInt32Length((int)dictionarySize) +
-            VarIntBE.CalcInt32Length(0);
-            VarIntBE.CalcInt32Length(lengthOfDelta);
 
             //Google's Checksum Implementation Support
             if (this.ChecksumFormat != ChecksumFormat.None)

--- a/src/VCDiff/Encoders/WindowEncoder.cs
+++ b/src/VCDiff/Encoders/WindowEncoder.cs
@@ -229,9 +229,9 @@ namespace VCDiff.Encoders
                     }
                 }
 
-                outputStream.Write(dataForAddAndRun.GetBuffer().AsSpan(0, (int)dataForAddAndRun.Length)); //data section for adds and runs
-                outputStream.Write(instructionAndSizes.GetBuffer().AsSpan(0, (int)instructionAndSizes.Length)); //data for instructions and sizes
-                outputStream.Write(addressForCopy.GetBuffer().AsSpan(0, (int)addressForCopy.Length)); //data for addresses section copys
+                outputStream.Write(dataForAddAndRun.GetBuffer().AsSpanFast((int)dataForAddAndRun.Length)); //data section for adds and runs
+                outputStream.Write(instructionAndSizes.GetBuffer().AsSpanFast((int)instructionAndSizes.Length)); //data for instructions and sizes
+                outputStream.Write(addressForCopy.GetBuffer().AsSpanFast((int)addressForCopy.Length)); //data for addresses section copys
             }
             else
             {

--- a/src/VCDiff/Shared/AddressCache.cs
+++ b/src/VCDiff/Shared/AddressCache.cs
@@ -16,7 +16,7 @@ namespace VCDiff.Shared
         private long[] sameCache;
         private int nextSlot;
         
-        public byte FirstNear => (byte)VCDiffModes.FIRST;
+        public const byte FirstNear = (byte)VCDiffModes.FIRST;
 
         public byte FirstSame => (byte)(VCDiffModes.FIRST + nearSize);
 

--- a/src/VCDiff/Shared/AddressCache.cs
+++ b/src/VCDiff/Shared/AddressCache.cs
@@ -203,7 +203,7 @@ namespace VCDiff.Shared
                         return encoded;
 
                     case (int)VCDiffResult.EOD:
-                        sin.Position = start;
+                        sin.Position = (int) start;
                         return encoded;
                 }
 

--- a/src/VCDiff/Shared/AddressCache.cs
+++ b/src/VCDiff/Shared/AddressCache.cs
@@ -15,54 +15,14 @@ namespace VCDiff.Shared
         private long[] nearCache;
         private long[] sameCache;
         private int nextSlot;
+        
+        public byte FirstNear => (byte)VCDiffModes.FIRST;
 
-        public byte NearSize
-        {
-            get
-            {
-                return nearSize;
-            }
-        }
+        public byte FirstSame => (byte)(VCDiffModes.FIRST + nearSize);
 
-        public byte SameSize
-        {
-            get
-            {
-                return sameSize;
-            }
-        }
+        public byte Last => (byte)(FirstSame + sameSize - 1);
 
-        public byte FirstNear
-        {
-            get
-            {
-                return (byte)VCDiffModes.FIRST;
-            }
-        }
-
-        public byte FirstSame
-        {
-            get
-            {
-                return (byte)(VCDiffModes.FIRST + nearSize);
-            }
-        }
-
-        public byte Last
-        {
-            get
-            {
-                return (byte)(FirstSame + sameSize - 1);
-            }
-        }
-
-        public static byte DefaultLast
-        {
-            get
-            {
-                return (byte)(VCDiffModes.FIRST + DefaultNearCacheSize + DefaultSameCacheSize - 1);
-            }
-        }
+        public static byte DefaultLast => (byte)(VCDiffModes.FIRST + DefaultNearCacheSize + DefaultSameCacheSize - 1);
 
         public AddressCache(byte nearSize, byte sameSize)
         {

--- a/src/VCDiff/Shared/Adler32.cs
+++ b/src/VCDiff/Shared/Adler32.cs
@@ -45,25 +45,6 @@ namespace VCDiff.Shared
         }
 #endif
 
-        public static uint Combine(uint adler1, uint adler2, uint len)
-        {
-            uint sum1 = 0;
-            uint sum2 = 0;
-            uint rem = 0;
-
-            rem = len % BASE;
-            sum1 = adler1 & 0xffff;
-            sum2 = rem * sum1;
-            sum2 %= BASE;
-            sum1 += (adler2 & 0xffff) + BASE - 1;
-            sum2 += ((adler1 >> 16) & 0xffff) + ((adler2 >> 16) & 0xffff) + BASE - rem;
-            if (sum1 >= BASE) sum1 -= BASE;
-            if (sum1 >= BASE) sum1 -= BASE;
-            if (sum2 >= (BASE << 1)) sum2 -= (BASE << 1);
-            if (sum2 >= BASE) sum2 -= BASE;
-            return sum1 | (sum2 << 16);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Do(ref uint adler, ref uint sum2, ReadOnlySpan<byte> buffer, int i, int times)
         {

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace VCDiff.Shared
@@ -61,7 +62,7 @@ namespace VCDiff.Shared
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe Span<byte> AsSpan() => new Span<byte>(bytePtr, length);
+        public unsafe Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Unsafe.AsRef<byte>(bytePtr), length);
 
         /// <summary>
         /// Dangerously gets the byte pointer.
@@ -110,6 +111,7 @@ namespace VCDiff.Shared
         public Span<byte> PeekBytes(int len)
         {
             int sliceLen = offset + len > this.length ? this.length - offset : len;
+
             return AsSpan().Slice(offset, sliceLen);
         }
 

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -22,6 +22,11 @@ namespace VCDiff.Shared
 
         }
 
+        ~ByteBuffer()
+        {
+            Dispose();
+        }
+
         /// <summary/>
         public unsafe ByteBuffer(byte[] bytes)
         {
@@ -135,6 +140,10 @@ namespace VCDiff.Shared
 
         public void Next() => offset++;
 
-        public void Dispose() => this.byteHandle?.Dispose();
+        public void Dispose()
+        {
+            this.byteHandle?.Dispose();
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -6,7 +6,10 @@ using System.Threading.Tasks;
 
 namespace VCDiff.Shared
 {
-    internal class ByteBuffer : IByteBuffer, IDisposable
+    /// <summary>
+    /// Encapsulates a buffer that reads bytes from managed or unmanaged memory.
+    /// </summary>
+    public class ByteBuffer : IByteBuffer, IDisposable
     {
         private MemoryHandle? byteHandle;
         private unsafe byte*  bytePtr;
@@ -18,10 +21,7 @@ namespace VCDiff.Shared
 
         }
 
-        /// <summary>
-        /// Basically a simple wrapper for byte[] arrays
-        /// for easier reading and parsing.
-        /// </summary>
+        /// <summary/>
         public unsafe ByteBuffer(byte[] bytes)
         {
             offset = 0;
@@ -30,6 +30,7 @@ namespace VCDiff.Shared
             CreateFromPointer((byte*)this.byteHandle.Value.Pointer, memory.Length);
         }
 
+        /// <summary/>
         public unsafe ByteBuffer(Memory<byte> bytes)
         {
             offset = 0;
@@ -37,6 +38,7 @@ namespace VCDiff.Shared
             CreateFromPointer((byte*)this.byteHandle.Value.Pointer, bytes.Length);
         }
 
+        /// <summary/>
         public unsafe ByteBuffer(Span<byte> bytes)
         {
             offset = 0;
@@ -45,6 +47,7 @@ namespace VCDiff.Shared
             CreateFromPointer((byte*)Unsafe.AsPointer(ref bytes.GetPinnableReference()), bytes.Length);
         }
 
+        /// <summary/>
         public unsafe ByteBuffer(byte* bytes, int length)
         {
             offset = 0;
@@ -86,16 +89,16 @@ namespace VCDiff.Shared
             get => offset < length;
         }
 
-        public long Position
+        public int Position
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => offset;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             // We used to check, but this is never true in calls. if (value > length || value < 0) return;
-            set => offset = (int)value;
+            set => offset = value;
         }
 
-        public long Length {         
+        public int Length {         
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => length;
         }

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -39,25 +39,6 @@ namespace VCDiff.Shared
             length = this.bytes.Length;
         }
 
-        public static async Task<ByteBuffer> CreateBufferAsync(Stream copyStream)
-        {
-            var buffer = new ByteBuffer { copyStream = new MemoryStream() };
-            await copyStream.CopyToAsync(buffer.copyStream);
-            buffer.copyStream.Seek(0, SeekOrigin.Begin);
-            buffer.offset = 0;
-            buffer.buf = buffer.copyStream.GetBuffer();
-            buffer.bytes = new Memory<byte>(buffer.buf, 0, (int)copyStream.Length);
-            buffer.byteHandle = buffer.bytes.Pin();
-            unsafe
-            {
-                buffer.bytePtr = (byte*)buffer.byteHandle.Pointer;
-            }
-
-            buffer.length = buffer.bytes.Length;
-
-            return buffer;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte[]? DangerousGetMemoryStreamBuffer() => buf;
 

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -108,11 +108,10 @@ namespace VCDiff.Shared
         public unsafe byte PeekByte() => *((byte*)this.bytePtr + offset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<byte> PeekBytes(int len)
+        public unsafe Span<byte> PeekBytes(int len)
         {
             int sliceLen = offset + len > this.length ? this.length - offset : len;
-
-            return AsSpan().Slice(offset, sliceLen);
+            return MemoryMarshal.CreateSpan(ref Unsafe.AsRef<byte>(bytePtr + offset), sliceLen);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -123,6 +123,14 @@ namespace VCDiff.Shared
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<byte> ReadBytesToSpan(Span<byte> data)
+        {
+            var result = PeekBytes(data.Length);
+            result.CopyTo(data);
+            return result.Slice(0, result.Length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte ReadByte() => this.bytePtr[offset++];
 
 #if NET5_0

--- a/src/VCDiff/Shared/ByteBuffer.cs
+++ b/src/VCDiff/Shared/ByteBuffer.cs
@@ -112,6 +112,9 @@ namespace VCDiff.Shared
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte PeekByte() => *((byte*)this.bytePtr + offset);
 
+#if NET5_0
+        [SkipLocalsInit]
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe Span<byte> PeekBytes(int len)
         {
@@ -122,6 +125,9 @@ namespace VCDiff.Shared
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte ReadByte() => this.bytePtr[offset++];
 
+#if NET5_0
+        [SkipLocalsInit]
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<byte> ReadBytesAsSpan(int len)
         {

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -24,12 +24,7 @@ namespace VCDiff.Shared
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int) buffer.Position;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            {
-
-                if (buffer.CanRead && value >= 0)
-                    buffer.Seek(value, SeekOrigin.Begin);
-            }
+            set => buffer.Seek(value, SeekOrigin.Begin);
         }
 
         public int Length

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -18,6 +18,7 @@ namespace VCDiff.Shared
         private readonly Stream buffer;
         private int lastLenRead;
         private byte[] cache;
+        private bool _isDisposed = false;
 
         public ByteStreamReader(Stream stream)
         {
@@ -45,6 +46,13 @@ namespace VCDiff.Shared
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => buffer.CanRead && buffer.Position < buffer.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<byte> ReadBytesToSpan(Span<byte> data)
+        {
+            int bytesRead = buffer.Read(data);
+            return data.Slice(0, bytesRead);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -115,7 +123,12 @@ namespace VCDiff.Shared
 
         public void Dispose()
         {
-            ArrayPool<byte>.Shared.Return(cache, false);
+            if (!_isDisposed)
+            {
+                ArrayPool<byte>.Shared.Return(cache, false);
+                _isDisposed = true;
+            }
+
             GC.SuppressFinalize(this);
         }
 

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -45,30 +45,18 @@ namespace VCDiff.Shared
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Memory<byte> PeekBytes(int len)
-        {
-            long oldPos = buffer.Position;
-            Memory<byte> buf = new byte[len];
-
-            int actualRead = buffer.Read(buf.Span);
-            lastLenRead = actualRead;
-            if (actualRead > 0)
-            {
-                buffer.Seek(oldPos, SeekOrigin.Begin);
-                return buf[..actualRead];
-            }
-
-            buffer.Seek(oldPos, SeekOrigin.Begin);
-            return Memory<byte>.Empty;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte ReadByte()
         {
             lastLenRead = buffer.ReadByte();
             if (lastLenRead > -1)
                 return (byte)lastLenRead;
             return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<byte> ReadBytesAsSpan(int len)
+        {
+            return ReadBytes(len).Span;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -56,7 +56,10 @@ namespace VCDiff.Shared
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<byte> ReadBytesAsSpan(int len)
         {
-            return ReadBytes(len).Span;
+            var buf = new byte[len];
+            int actualRead = buffer.Read(buf, 0, buf.Length);
+            lastLenRead = actualRead;
+            return actualRead > 0 ? buf.AsSpan()[..actualRead] : Span<byte>.Empty;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace VCDiff.Shared
 {
@@ -83,6 +84,15 @@ namespace VCDiff.Shared
         public int ReadBytesIntoBuf(Span<byte> buf)
         {
             int actualRead = buffer.Read(buf);
+            lastLenRead = actualRead;
+            return actualRead;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public async Task<int> ReadBytesIntoBufAsync(Memory<byte> buf)
+        {
+            int actualRead = await buffer.ReadAsync(buf);
             lastLenRead = actualRead;
             return actualRead;
         }

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -9,7 +9,7 @@ namespace VCDiff.Shared
     //Wrapper Class for any stream that supports Position
     //and Length to make reading bytes easier
     //also has a helper function for reading all the bytes in at once
-    internal class ByteStreamReader : IByteBuffer
+    public class ByteStreamReader : IByteBuffer
     {
         private readonly Stream buffer;
         private int lastLenRead;
@@ -95,5 +95,7 @@ namespace VCDiff.Shared
         {
             buffer.Seek(1, SeekOrigin.Current);
         }
+
+        public void Dispose() { }
     }
 }

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -62,10 +62,10 @@ namespace VCDiff.Shared
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<byte> ReadBytes(int len)
         {
-            Memory<byte> buf = new byte[len];
-            int actualRead = buffer.Read(buf.Span);
+            var buf = new byte[len];
+            int actualRead = buffer.Read(buf, 0, buf.Length);
             lastLenRead = actualRead;
-            return actualRead > 0 ? buf[..actualRead] : Memory<byte>.Empty;
+            return actualRead > 0 ? buf.AsMemory()[..actualRead] : Memory<byte>.Empty;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/VCDiff/Shared/ByteStreamReader.cs
+++ b/src/VCDiff/Shared/ByteStreamReader.cs
@@ -19,10 +19,10 @@ namespace VCDiff.Shared
             buffer = stream;
         }
 
-        public long Position
+        public int Position
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => buffer.Position;
+            get => (int) buffer.Position;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
@@ -32,10 +32,10 @@ namespace VCDiff.Shared
             }
         }
 
-        public long Length
+        public int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => buffer.CanRead? buffer.Length: 0;
+            get => (int)(buffer.CanRead ? buffer.Length : 0);
         }
 
         public bool CanRead

--- a/src/VCDiff/Shared/Checksum.cs
+++ b/src/VCDiff/Shared/Checksum.cs
@@ -6,15 +6,15 @@ namespace VCDiff.Shared
     internal class Checksum
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ComputeGoogleAdler32(ReadOnlyMemory<byte> buffer)
+        public static uint ComputeGoogleAdler32(ReadOnlySpan<byte> buffer)
         {
-            return Adler32.Hash(0, buffer.Span);
+            return Adler32.Hash(0, buffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ComputeXdelta3Adler32(ReadOnlyMemory<byte> buffer)
+        public static uint ComputeXdelta3Adler32(ReadOnlySpan<byte> buffer)
         {
-            return Adler32.Hash(1, buffer.Span);
+            return Adler32.Hash(1, buffer);
         }
     }
 }

--- a/src/VCDiff/Shared/Checksum.cs
+++ b/src/VCDiff/Shared/Checksum.cs
@@ -16,10 +16,5 @@ namespace VCDiff.Shared
         {
             return Adler32.Hash(1, buffer.Span);
         }
-
-        public static long UpdateAdler32(uint partial, ReadOnlyMemory<byte> buffer)
-        {
-            return Adler32.Hash(partial, buffer.Span);
-        }
     }
 }

--- a/src/VCDiff/Shared/CodeTable.cs
+++ b/src/VCDiff/Shared/CodeTable.cs
@@ -14,12 +14,12 @@ namespace VCDiff.Shared
 
         public byte[] table = new byte[kCodeTableSize * 6];
 
-        public NativeAllocation inst1;
-        public NativeAllocation inst2;
-        public NativeAllocation size1;
-        public NativeAllocation size2;
-        public NativeAllocation mode1;
-        public NativeAllocation mode2;
+        public NativeAllocation<byte> inst1;
+        public NativeAllocation<byte> inst2;
+        public NativeAllocation<byte> size1;
+        public NativeAllocation<byte> size2;
+        public NativeAllocation<byte> mode1;
+        public NativeAllocation<byte> mode2;
 
         public const byte N = (byte)VCDiffInstructionType.NOOP;
         public const byte A = (byte)VCDiffInstructionType.ADD;
@@ -191,10 +191,10 @@ namespace VCDiff.Shared
             Dispose();
         }
 
-        private void InitTableSegment(int row, byte[] defaultBytes, ref NativeAllocation alloc)
+        private void InitTableSegment(int row, byte[] defaultBytes, ref NativeAllocation<byte> alloc)
         {
             var rowSpan = table.AsSpan(row * kCodeTableSize, kCodeTableSize);
-            alloc = new NativeAllocation(rowSpan.Length);
+            alloc = new NativeAllocation<byte>(rowSpan.Length);
             defaultBytes.CopyTo(alloc.AsSpan());
         }
 

--- a/src/VCDiff/Shared/CodeTable.cs
+++ b/src/VCDiff/Shared/CodeTable.cs
@@ -172,7 +172,7 @@ namespace VCDiff.Shared
                 0, 0, 0, 0, 0, 0, 0, 0, 0  // opcodes 247-255
             };
 
-        public static CodeTable DefaultTable => new CodeTable();
+        public static CodeTable DefaultTable = new CodeTable();
 
         public CodeTable()
         {

--- a/src/VCDiff/Shared/Extensions.cs
+++ b/src/VCDiff/Shared/Extensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace VCDiff.Shared
+{
+    internal static class Extensions
+    {
+        public static Span<byte> AsSpanFast(this byte[] data)
+        {
+#if NET5_0
+            return MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(data), data.Length);
+#else
+            return data.AsSpan();
+#endif
+        }
+
+        public static Span<byte> AsSpanFast(this byte[] data, int length)
+        {
+#if NET5_0
+            return MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(data), length);
+#else
+            return data.AsSpan(0, length);
+#endif
+        }
+
+    }
+}

--- a/src/VCDiff/Shared/IByteBuffer.cs
+++ b/src/VCDiff/Shared/IByteBuffer.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+#pragma warning disable 1591
 
 namespace VCDiff.Shared
 {
-    internal interface IByteBuffer 
+    public interface IByteBuffer : IDisposable
     {
         int Length
         {

--- a/src/VCDiff/Shared/IByteBuffer.cs
+++ b/src/VCDiff/Shared/IByteBuffer.cs
@@ -5,13 +5,13 @@ namespace VCDiff.Shared
 {
     internal interface IByteBuffer 
     {
-        long Length
+        int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get; 
         }
 
-        long Position
+        int Position
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get;

--- a/src/VCDiff/Shared/IByteBuffer.cs
+++ b/src/VCDiff/Shared/IByteBuffer.cs
@@ -29,9 +29,10 @@ namespace VCDiff.Shared
         Memory<byte> ReadBytes(int len);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        byte ReadByte();
+        Span<byte> ReadBytesAsSpan(int len);
 
-        Memory<byte> PeekBytes(int len);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        byte ReadByte();
 
         byte PeekByte();
 

--- a/src/VCDiff/Shared/IByteBuffer.cs
+++ b/src/VCDiff/Shared/IByteBuffer.cs
@@ -33,6 +33,9 @@ namespace VCDiff.Shared
         Span<byte> ReadBytesAsSpan(int len);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        Span<byte> ReadBytesToSpan(Span<byte> data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         byte ReadByte();
 
         byte PeekByte();

--- a/src/VCDiff/Shared/Intrinsics.cs
+++ b/src/VCDiff/Shared/Intrinsics.cs
@@ -43,7 +43,7 @@ namespace VCDiff.Shared
         public static unsafe void FillArrayVectorized(long* first, int numValues, long value)
         {
 #if NETCOREAPP3_1 || NET5_0
-            int bytesLeft = numValues * sizeof(long);
+            long bytesLeft = (long) numValues * sizeof(long);
             if (bytesLeft >= MaxRegisterSize)
             {
                 // Note: This can be 0 cost in .NET 5 when paired with pinned GC.AllocateUnitializedArray.

--- a/src/VCDiff/Shared/Intrinsics.cs
+++ b/src/VCDiff/Shared/Intrinsics.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+#if NETCOREAPP3_1 || NET5_0
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace VCDiff.Shared
+{
+    internal static class Intrinsics
+    {
+        public const int AvxRegisterSize = 32;
+        public const int SseRegisterSize = 16;
+        public static readonly int MaxRegisterSize;
+        public static readonly bool UseAvx;
+
+        static Intrinsics()
+        {
+#if NETCOREAPP3_1 || NET5_0
+            if (Sse2.IsSupported)
+            {
+                MaxRegisterSize = SseRegisterSize;
+                UseAvx = false;
+            }
+
+            if (Avx.IsSupported)
+            {
+                MaxRegisterSize = AvxRegisterSize;
+                UseAvx = true;
+            }
+
+            // Not set.
+            if (MaxRegisterSize == 0)
+            {
+                // bytesLeft will never exceed.
+                MaxRegisterSize = int.MaxValue;
+            }
+#endif
+        }
+
+        public static unsafe void FillArrayVectorized(long[] array, long value)
+        {
+#if NETCOREAPP3_1 || NET5_0
+            int bytesLeft = array.Length * sizeof(long);
+            if (bytesLeft >= MaxRegisterSize)
+            {
+                // Note: This can be 0 cost in .NET 5 when paired with pinned GC.AllocateUnitializedArray.
+                fixed (long* first = &array[0])
+                {
+                    if (UseAvx)
+                        Avx2FillArray(first, value, ref bytesLeft);
+                    else
+                        Sse2FillArray(first, value, ref bytesLeft);
+
+                    // Fill rest of array.
+                    var elementsLeft = bytesLeft / sizeof(long);
+                    for (int x = array.Length - elementsLeft; x < array.Length; x++)
+                        array[x] = value;
+                }
+            }
+            else
+            {
+                // Copy remaining elements.
+                for (int x = 0; x < array.Length; x++)
+                    array[x] = value;
+            }
+#else
+            // Accelerate via loop unrolled solution.
+            array.AsSpan().Fill(value);
+#endif
+        }
+
+
+#if NETCOREAPP3_1 || NET5_0
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static unsafe void Sse2FillArray(long* first, long value, ref int bytesLeft)
+        {
+            // Initialize.
+            var numValues = SseRegisterSize / sizeof(long);
+            var vectorValues = stackalloc long[numValues];
+            FillPointer(vectorValues, value, numValues);
+
+            var vector = Sse2.LoadVector128(vectorValues);
+            while (bytesLeft >= SseRegisterSize)
+            {
+                Sse2.Store(first, vector);
+                first += numValues;
+                bytesLeft -= SseRegisterSize;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static unsafe void Avx2FillArray(long* first, long value, ref int bytesLeft)
+        {
+            // Initialize.
+            var numValues    = AvxRegisterSize / sizeof(long);
+            var vectorValues = stackalloc long[numValues];
+            FillPointer(vectorValues, value, numValues);
+
+            var vector = Avx2.LoadVector256(vectorValues);
+            while (bytesLeft >= AvxRegisterSize)
+            {
+                Avx2.Store(first, vector);
+                first += numValues;
+                bytesLeft -= AvxRegisterSize;
+            }
+        }
+
+        private static unsafe void FillPointer(long* values, long value, int numValues)
+        {
+            for (int x = 0; x < numValues; x++)
+            {
+                *values = value;
+                values += 1;
+            }
+        }
+#endif
+    }
+}

--- a/src/VCDiff/Shared/Intrinsics.cs
+++ b/src/VCDiff/Shared/Intrinsics.cs
@@ -43,7 +43,7 @@ namespace VCDiff.Shared
         public static unsafe void FillArrayVectorized(long* first, int numValues, long value)
         {
 #if NETCOREAPP3_1 || NET5_0
-            long bytesLeft = (long) numValues * sizeof(long);
+            long bytesLeft = (long)((long)numValues * sizeof(long));
             if (bytesLeft >= MaxRegisterSize)
             {
                 // Note: This can be 0 cost in .NET 5 when paired with pinned GC.AllocateUnitializedArray.
@@ -53,7 +53,7 @@ namespace VCDiff.Shared
                     Sse2FillArray(first, value, ref bytesLeft);
                     
                 // Fill rest of array.
-                var elementsLeft = bytesLeft / sizeof(long);
+                var elementsLeft = (int)(bytesLeft / sizeof(long));
                 for (int x = numValues - elementsLeft; x < numValues; x++)
                     first[x] = value;
             }
@@ -72,7 +72,7 @@ namespace VCDiff.Shared
 
 #if NETCOREAPP3_1 || NET5_0
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        private static unsafe void Sse2FillArray(long* first, long value, ref int bytesLeft)
+        private static unsafe void Sse2FillArray(long* first, long value, ref long bytesLeft)
         {
             // Initialize.
             var numValues = SseRegisterSize / sizeof(long);
@@ -89,7 +89,7 @@ namespace VCDiff.Shared
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        private static unsafe void Avx2FillArray(long* first, long value, ref int bytesLeft)
+        private static unsafe void Avx2FillArray(long* first, long value, ref long bytesLeft)
         {
             // Initialize.
             var numValues    = AvxRegisterSize / sizeof(long);

--- a/src/VCDiff/Shared/NativeAllocation.cs
+++ b/src/VCDiff/Shared/NativeAllocation.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace VCDiff.Shared
+{
+    internal struct NativeAllocation : IDisposable
+    {
+        public IntPtr Address;
+        public int Size;
+        public bool OwnsAllocation;
+
+        public NativeAllocation(int size)
+        {
+            Address = Marshal.AllocHGlobal(size);
+            Size = size;
+            OwnsAllocation = true;
+        }
+
+        public NativeAllocation(IntPtr address, int size) : this()
+        {
+            Address = address;
+            Size = size;
+            OwnsAllocation = false;
+        }
+
+        public unsafe Span<byte> AsSpan() => new Span<byte>((void*) Address, Size);
+
+        public void Dispose()
+        {
+            if (Address != IntPtr.Zero)
+                Marshal.FreeHGlobal(Address);
+        }
+    }
+}

--- a/src/VCDiff/Shared/NativeAllocation.cs
+++ b/src/VCDiff/Shared/NativeAllocation.cs
@@ -11,7 +11,8 @@ namespace VCDiff.Shared
 
         public NativeAllocation(int numItems)
         {
-            Pointer = (T*) Marshal.AllocHGlobal(numItems * sizeof(T));
+            var bytes = (long)numItems * sizeof(T);
+            Pointer = (T*) Marshal.AllocHGlobal((IntPtr) bytes);
             NumItems = numItems;
             OwnsAllocation = true;
         }

--- a/src/VCDiff/Shared/NativeAllocation.cs
+++ b/src/VCDiff/Shared/NativeAllocation.cs
@@ -3,32 +3,32 @@ using System.Runtime.InteropServices;
 
 namespace VCDiff.Shared
 {
-    internal struct NativeAllocation : IDisposable
+    internal unsafe struct NativeAllocation : IDisposable
     {
-        public IntPtr Address;
+        public byte* Pointer;
         public int Size;
         public bool OwnsAllocation;
 
         public NativeAllocation(int size)
         {
-            Address = Marshal.AllocHGlobal(size);
+            Pointer = (byte*) Marshal.AllocHGlobal(size);
             Size = size;
             OwnsAllocation = true;
         }
 
         public NativeAllocation(IntPtr address, int size) : this()
         {
-            Address = address;
+            Pointer = (byte*) address;
             Size = size;
             OwnsAllocation = false;
         }
 
-        public unsafe Span<byte> AsSpan() => new Span<byte>((void*) Address, Size);
+        public unsafe Span<byte> AsSpan() => new Span<byte>((void*) Pointer, Size);
 
         public void Dispose()
         {
-            if (Address != IntPtr.Zero)
-                Marshal.FreeHGlobal(Address);
+            if (Pointer != (void*)0)
+                Marshal.FreeHGlobal((IntPtr) Pointer);
         }
     }
 }

--- a/src/VCDiff/Shared/NativeAllocation.cs
+++ b/src/VCDiff/Shared/NativeAllocation.cs
@@ -3,27 +3,27 @@ using System.Runtime.InteropServices;
 
 namespace VCDiff.Shared
 {
-    internal unsafe struct NativeAllocation : IDisposable
+    internal unsafe struct NativeAllocation<T> : IDisposable where T : unmanaged
     {
-        public byte* Pointer;
-        public int Size;
+        public T* Pointer;
+        public int NumItems;
         public bool OwnsAllocation;
 
-        public NativeAllocation(int size)
+        public NativeAllocation(int numItems)
         {
-            Pointer = (byte*) Marshal.AllocHGlobal(size);
-            Size = size;
+            Pointer = (T*) Marshal.AllocHGlobal(numItems * sizeof(T));
+            NumItems = numItems;
             OwnsAllocation = true;
         }
 
         public NativeAllocation(IntPtr address, int size) : this()
         {
-            Pointer = (byte*) address;
-            Size = size;
+            Pointer = (T*) address;
+            NumItems = size;
             OwnsAllocation = false;
         }
 
-        public unsafe Span<byte> AsSpan() => new Span<byte>((void*) Pointer, Size);
+        public unsafe Span<byte> AsSpan() => new Span<byte>((void*) Pointer, NumItems);
 
         public void Dispose()
         {

--- a/src/VCDiff/Shared/PinnedArrayRental.cs
+++ b/src/VCDiff/Shared/PinnedArrayRental.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace VCDiff.Shared
+{
+    internal struct PinnedArrayRental : IDisposable
+    {
+        /// <summary>
+        /// The data encapsulated by this rental.
+        /// </summary>
+        public byte[]? Data { get; private set; }
+
+        /// <summary>
+        /// The number of bytes in this object.
+        /// </summary>
+        public int NumBytes { get; private set; }
+
+        /// <summary>
+        /// Converts the data to a span.
+        /// </summary>
+        public Span<byte> AsSpan() => Data!.AsSpanFast(NumBytes);
+
+        private GCHandle _pin;
+
+        /// <summary>
+        /// Converts the data to a span or an empty span.
+        /// </summary>
+        public Span<byte> AsSpanOrDefault()
+        {
+            if (Data != null)
+                return Data.AsSpanFast(NumBytes);
+
+            return Span<byte>.Empty;
+        }
+
+        public PinnedArrayRental(int numBytes)
+        {
+            NumBytes = numBytes;
+            Data = ArrayPool<byte>.Shared.Rent(NumBytes);
+            Debug.Assert(Data.Length >= numBytes);
+            _pin = GCHandle.Alloc(Data, GCHandleType.Pinned);
+        }
+
+        public void Dispose()
+        {
+            if (Data != null)
+            {
+                _pin.Free();
+                ArrayPool<byte>.Shared.Return(Data, false);
+                Data = null;
+            }
+        }
+    }
+}

--- a/src/VCDiff/Shared/Pool.cs
+++ b/src/VCDiff/Shared/Pool.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.IO;
+
+namespace VCDiff.Shared
+{
+    internal static class Pool
+    {
+        const int BlockSize = RecyclableMemoryStreamManager.DefaultBlockSize;
+        
+        /// <summary>
+        /// For large buffers, multiplies the buffer linearly by this amount.
+        /// </summary>
+        const int LargeBufferMultiple = 1024 * 1024; // 1 MiB
+
+        /// <summary>
+        /// ~2 GiB 
+        /// </summary>
+        const int MaxBufferSize = LargeBufferMultiple * 2047;
+
+        public static RecyclableMemoryStreamManager MemoryStreamManager = new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize)
+        {
+            AggressiveBufferReturn = true,
+            ThrowExceptionOnToArray = true
+        };
+    }
+}

--- a/src/VCDiff/Shared/VarIntBE.cs
+++ b/src/VCDiff/Shared/VarIntBE.cs
@@ -17,7 +17,7 @@ namespace VCDiff.Shared
         public const int int32MaxValue = 0x7FFFFFFF;
         public const long int64MaxValue = 0x7FFFFFFFFFFFFFFF;
 
-        public static int ParseInt32(IByteBuffer sin)
+        public static int ParseInt32<TByteBuffer>(TByteBuffer sin) where TByteBuffer : IByteBuffer
         {
             int result = 0;
             while (sin.CanRead)
@@ -38,7 +38,7 @@ namespace VCDiff.Shared
             return (int)VCDiffResult.EOD;
         }
 
-        public static long ParseInt64(IByteBuffer sin)
+        public static long ParseInt64<TByteBuffer>(TByteBuffer sin) where TByteBuffer : IByteBuffer
         {
             long result = 0;
             while (sin.CanRead)

--- a/src/VCDiff/VCDiff.csproj
+++ b/src/VCDiff/VCDiff.csproj
@@ -21,6 +21,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
   </ItemGroup>
 </Project>

--- a/src/VCDiff/VCDiff.csproj
+++ b/src/VCDiff/VCDiff.csproj
@@ -4,11 +4,12 @@
   <PropertyGroup>
     <RootNamespace>VCDiff</RootNamespace>
     <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>
     <Version>3.3.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <Authors>Metric;chyyran;Snowflake Authors</Authors>
     <PackageTags>diff;difference;patch;sdch;compare;delta;vcdiff;bsdiff</PackageTags>

--- a/src/VCDiff/VCDiff.csproj
+++ b/src/VCDiff/VCDiff.csproj
@@ -19,4 +19,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+  </ItemGroup>
 </Project>

--- a/src/VCDiff/VCDiff.xml
+++ b/src/VCDiff/VCDiff.xml
@@ -255,6 +255,32 @@
              </param>
              <exception cref="T:System.ArgumentException">If an invalid blockSize or chunkSize is used..</exception>
         </member>
+        <member name="M:VCDiff.Encoders.VcEncoder.#ctor(VCDiff.Shared.ByteBuffer,System.IO.Stream,System.IO.Stream,System.Int32,System.Int32,System.Int32,VCDiff.Encoders.RollingHash)">
+             <summary>
+             Creates a new VCDIFF Encoder. The input streams will not be closed once this object is disposed.
+             </summary>
+             <param name="buffer">The dictionary (source file).</param>
+             <param name="target">The target to create the diff from.</param>
+             <param name="outputStream">The stream to write the diff into.</param>
+             <param name="maxBufferSize">The maximum buffer size for window chunking in megabytes (MiB).</param>
+             <param name="blockSize">
+             The block size to use. Must be a power of two. No match smaller than this block size will be identified.
+             Increasing blockSize by a factor of two will halve the amount of memory needed for the next block table, and will halve the setup time
+             for a new BlockHash.  However, it also doubles the minimum match length that is guaranteed to be found.
+             
+             Blocksizes that are n mod 32 = 0 are AVX2 accelerated. Blocksizes that are n mod 16 = 0 are SSE2 accelerated, if supported. 16 is a good default
+             for most scenarios, but you should use a block size of 32 or 64 for very similar data, or to optimize for speed.
+             </param>
+             <param name="chunkSize">
+             The minimum size of a string match that is worth putting into a COPY. This must be bigger than twice the block size.</param>
+             <param name="rollingHash">
+             Manually provide a <see cref="T:VCDiff.Encoders.RollingHash"/> instance that can be reused for multiple encoding instances
+             of the same block size.
+            
+             If you provide a <see cref="T:VCDiff.Encoders.RollingHash"/> instance, you must dispose of it yourself.
+             </param>
+             <exception cref="T:System.ArgumentException">If an invalid blockSize or chunkSize is used..</exception>
+        </member>
         <member name="M:VCDiff.Encoders.VcEncoder.Encode(System.Boolean,VCDiff.Shared.ChecksumFormat,System.IProgress{System.Single})">
             <summary>
             Calculate and write a diff for the file.
@@ -272,9 +298,7 @@
         <member name="M:VCDiff.Encoders.VcEncoder.EncodeAsync(System.Boolean,VCDiff.Shared.ChecksumFormat,System.IProgress{System.Single})">
             <summary>
             Calculate and write a diff for the file.
-            
-            This method is only asynchronous for buffering of <see cref="F:VCDiff.Encoders.VcEncoder.sourceStream"/> and <see cref="F:VCDiff.Encoders.VcEncoder.targetData"/>.
-            Writing to the output stream will still occur synchronously.
+            This method isn't fully asynchonous; writes to the output stream are still synchronous.
             
             It is recommended you use the synchronous <see cref="M:VCDiff.Encoders.VcEncoder.Encode(System.Boolean,VCDiff.Shared.ChecksumFormat,System.IProgress{System.Single})"/> method for most use cases.
             </summary>
@@ -332,11 +356,22 @@
             <param name="buff"></param>
             <returns></returns>
         </member>
-        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Byte[])">
+        <member name="T:VCDiff.Shared.ByteBuffer">
             <summary>
-            Basically a simple wrapper for byte[] arrays
-            for easier reading and parsing.
+            Encapsulates a buffer that reads bytes from managed or unmanaged memory.
             </summary>
+        </member>
+        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Byte[])">
+            <summary/>
+        </member>
+        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Memory{System.Byte})">
+            <summary/>
+        </member>
+        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Span{System.Byte})">
+            <summary/>
+        </member>
+        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Byte*,System.Int32)">
+            <summary/>
         </member>
         <member name="M:VCDiff.Shared.ByteBuffer.DangerousGetBytePointer">
             <summary>

--- a/src/VCDiff/VCDiff.xml
+++ b/src/VCDiff/VCDiff.xml
@@ -255,7 +255,7 @@
              </param>
              <exception cref="T:System.ArgumentException">If an invalid blockSize or chunkSize is used..</exception>
         </member>
-        <member name="M:VCDiff.Encoders.VcEncoder.Encode(System.Boolean,VCDiff.Shared.ChecksumFormat)">
+        <member name="M:VCDiff.Encoders.VcEncoder.Encode(System.Boolean,VCDiff.Shared.ChecksumFormat,System.IProgress{System.Single})">
             <summary>
             Calculate and write a diff for the file.
             </summary>
@@ -264,26 +264,29 @@
             Whether to include Adler32 checksums for encoded data windows. If interleaved is true, <see cref="F:VCDiff.Shared.ChecksumFormat.Xdelta3"/>
             is not supported.
             </param>
+            <param name="progress">Reports an estimate of the encoding progress. Value if 0 to 1.</param>
             <returns>
             <see cref="F:VCDiff.Includes.VCDiffResult.SUCCESS"/> if successful, <see cref="F:VCDiff.Includes.VCDiffResult.ERROR"/> if the sourceStream or target are zero-length.</returns>
             <exception cref="T:System.ArgumentException">If interleaved is true, and <see cref="F:VCDiff.Shared.ChecksumFormat.Xdelta3"/> is chosen.</exception>
         </member>
-        <member name="M:VCDiff.Encoders.VcEncoder.EncodeAsync(System.Boolean,VCDiff.Shared.ChecksumFormat)">
-             <summary>
-             Calculate and write a diff for the file.
+        <member name="M:VCDiff.Encoders.VcEncoder.EncodeAsync(System.Boolean,VCDiff.Shared.ChecksumFormat,System.IProgress{System.Single})">
+            <summary>
+            Calculate and write a diff for the file.
             
-             This method is only asynchronous for the initial buffering of the sourceStream into memory.
-             Writing to the output stream will still occur synchronously. 
-             It is recommended you use the synchronous <see cref="M:VCDiff.Encoders.VcEncoder.Encode(System.Boolean,VCDiff.Shared.ChecksumFormat)"/> method for most use cases.
-             </summary>
-             <param name="interleaved">Whether to output in SDCH interleaved diff format.</param>
-             <param name="checksumFormat">
-             Whether to include Adler32 checksums for encoded data windows. If interleaved is true, <see cref="F:VCDiff.Shared.ChecksumFormat.Xdelta3"/>
-             is not supported.
-             </param>
-             <returns>
-             <see cref="F:VCDiff.Includes.VCDiffResult.SUCCESS"/> if successful, <see cref="F:VCDiff.Includes.VCDiffResult.ERROR"/> if the sourceStream or target are zero-length.</returns>
-             <exception cref="T:System.ArgumentException">If interleaved is true, and <see cref="F:VCDiff.Shared.ChecksumFormat.Xdelta3"/> is chosen.</exception>
+            This method is only asynchronous for buffering of <see cref="F:VCDiff.Encoders.VcEncoder.sourceStream"/> and <see cref="F:VCDiff.Encoders.VcEncoder.targetData"/>.
+            Writing to the output stream will still occur synchronously.
+            
+            It is recommended you use the synchronous <see cref="M:VCDiff.Encoders.VcEncoder.Encode(System.Boolean,VCDiff.Shared.ChecksumFormat,System.IProgress{System.Single})"/> method for most use cases.
+            </summary>
+            <param name="interleaved">Whether to output in SDCH interleaved diff format.</param>
+            <param name="checksumFormat">
+            Whether to include Adler32 checksums for encoded data windows. If interleaved is true, <see cref="F:VCDiff.Shared.ChecksumFormat.Xdelta3"/>
+            is not supported.
+            </param>
+            <param name="progress">Reports an estimate of the encoding progress. Value if 0 to 1.</param>
+            <returns>
+            <see cref="F:VCDiff.Includes.VCDiffResult.SUCCESS"/> if successful, <see cref="F:VCDiff.Includes.VCDiffResult.ERROR"/> if the sourceStream or target are zero-length.</returns>
+            <exception cref="T:System.ArgumentException">If interleaved is true, and <see cref="F:VCDiff.Shared.ChecksumFormat.Xdelta3"/> is chosen.</exception>
         </member>
         <member name="M:VCDiff.Encoders.VcEncoder.Dispose">
             <summary>
@@ -319,6 +322,15 @@
             <summary>
             Zlib implementation of the Adler32 Hash
             </summary>
+        </member>
+        <member name="M:VCDiff.Shared.Adler32.HashSsse3(System.UInt32,System.ReadOnlySpan{System.Byte})">
+            <summary>
+            SSSE3 Version of Adler32
+            https://chromium.googlesource.com/chromium/src/third_party/zlib/+/master/adler32_simd.c
+            </summary>
+            <param name="adler"></param>
+            <param name="buff"></param>
+            <returns></returns>
         </member>
         <member name="M:VCDiff.Shared.ByteBuffer.DangerousGetBytePointer">
             <summary>

--- a/src/VCDiff/VCDiff.xml
+++ b/src/VCDiff/VCDiff.xml
@@ -332,6 +332,12 @@
             <param name="buff"></param>
             <returns></returns>
         </member>
+        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Byte[])">
+            <summary>
+            Basically a simple wrapper for byte[] arrays
+            for easier reading and parsing.
+            </summary>
+        </member>
         <member name="M:VCDiff.Shared.ByteBuffer.DangerousGetBytePointer">
             <summary>
             Dangerously gets the byte pointer.
@@ -344,13 +350,6 @@
             </summary>
             <param name="read"></param>
             <returns></returns>
-        </member>
-        <member name="M:VCDiff.Shared.ByteBuffer.#ctor(System.Byte[])">
-            <summary>
-            Basically a simple wrapper for byte[] arrays
-            for easier reading and parsing
-            </summary>
-            <param name="bytes"></param>
         </member>
         <member name="T:VCDiff.Shared.ChecksumFormat">
             <summary>


### PR DESCRIPTION
Hi, thanks for the performance optimizations.

I'm working on a delta patching algorithm for a mod loader; and was interested in a managed implementation of VCDiff. In the process, I ended up making some miscellaneous extra improvements to the implementation.

Summary
----------

- Removed duplicate code in `VCEncoder`.
- Removed unused code from internal APIs. e.g. `Adler32.Combine`
- Added Span<T> returns for `IByteBuffer` to reduce total number of heap allocations. New API used where possible.
- Support using `ByteBuffer` as source in `VCEncoder` (to avoid unnecessary memory copy).
- Faster copying of `Source` in VCEncoder (allocated array isn't zero initialized [default .NET Behaviour] as it will be entirely overwritten anyway).
- Added `[SkipLocalsInit]` attribute for .NET 5 target to methods with 1+ Million invocations (on 100MB+ files).
- Changed: Capped max `bufferSize` in `VCEncoder` to target length to avoid unnecessary excess memory allocation.
- Added: Reads from `target` in `EncodeAsync` are now asynchonous. Only writing to output now still isn't.
- Added: Usage of `GC.AllocateUninitializedArray` for .NET 5 in `BlockHash` to avoid implicit array zero fill.
- Added: Simple BenchmarkDotNet Program (`VCDiff.Benchmark`). 
- Added: Vector Fill `BlockHash` tables.
- Optimized: Bounds Checks on Vector Operations.
- Devirtualized VcDecoder (removed virtual method calls via eliminating interface)
- Added: Caching for small memory reads and less allocations in `ByteStreamReader`.
- Added: Read directly into `Span<T>` for `IByteBuffer`.
- Added: Use `Array Rentals` for less heap allocations on repeat decodes.
- Reduced: Unnecessary heap allocations; particularly using structs where appropriate and not re-creating e.g. InstructionMap unnecessarily.
- Removed: Unnecessary behind the hood `MemoryStream` allocations by using array pooling in `Microsoft.IO.RecyclableMemoryStream`.

Note
------
Although unused code was cleaned up a little, no public APIs were removed.
Code passes all tests as expected; should be slightly faster than before but I didn't strictly benchmark it.

Benchmarks
-------------

### Encode
Encoding a16 MB file 1 time.

Before:
|                 Method |    Bytes | BlockSize |     Mean |    Error |  StdDev |
|----------------------- |--------- |---------- |---------:|---------:|--------:|
| EncodeSlightlyModified | 16777216 |        32 | 173.7 ms |  7.74 ms | 4.05 ms |
|  EncodeHeavilyModified | 16777216 |        32 | 954.9 ms | 18.77 ms | 9.82 ms |


Current (15f0e67cb997a4a881051a14e1b6163e4c86e00d):
|                 Method |    Bytes | BlockSize |     Mean |   Error |  StdDev |
|----------------------- |--------- |---------- |---------:|--------:|--------:|
| EncodeSlightlyModified | 16777216 |        32 | 166.9 ms | 4.40 ms | 2.30 ms |
|  EncodeHeavilyModified | 16777216 |        32 | 887.8 ms | 3.07 ms | 1.61 ms |

### Decode
Decoding 16 MB file 128 times. (~2GB per run.)

Before:
|                 Method |    Bytes | BlockSize |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |      Gen 2 | Allocated |
|----------------------- |--------- |---------- |--------:|---------:|---------:|------------:|-----------:|-----------:|----------:|
| DecodeSlightlyModified | 16777216 |        32 | 2.820 s | 0.0890 s | 0.0466 s | 106000.0000 | 44000.0000 | 42000.0000 |      5 GB |
|  DecodeHeavilyModified | 16777216 |        32 | 1.095 s | 0.0136 s | 0.0071 s |  19000.0000 | 16000.0000 | 16000.0000 |      2 GB |

Current:
|                 Method |    Bytes | BlockSize |       Mean |   Error |  StdDev |     Gen 0 | Allocated |
|----------------------- |--------- |---------- |-----------:|--------:|--------:|----------:|----------:|
| DecodeSlightlyModified | 16777216 |        32 | 1,647.2 ms | 4.97 ms | 1.77 ms | 3000.0000 |     31 MB |
|  DecodeHeavilyModified | 16777216 |        32 |   466.5 ms | 6.25 ms | 2.77 ms | 3000.0000 |     31 MB |

For decode I've now come to a point where `MemoryStream` itself is the bottleneck; with a speed anywhere between 740MB/s and 1870MB/s depending on file.

Real World Tests
------------------
On an i7 4790k @ 4.4GHz & 1866MHz CL9 DDR3 RAM.
Input is a 1.4GB GameCube ROM and a modified version of said ROM with custom code and ~590MiB of music.
(Not actually what I plan on using it on but was a good test case)

xdelta3.0.11 x64 (cmd: `xdelta.exe -e -S -A -s`
- RAM (Private Working Bytes): 150 MB
- Time Taken: ~6.1 minutes.
- Patch Size: 980MiB

vcdiff (15f0e67cb997a4a881051a14e1b6163e4c86e00d)
- RAM (Private Working Bytes): 6.1GB (No Change)
- Time Taken: ~10.8 minutes.
- Patch Size: 619MiB

Not the only ROM I've tested. Another game mod with equal amount of custom files yielded an even greater patch size improvement from 1320MiB to 620MiB. 

There's a chance that xdelta is performing some sort of tricks to optimise speed over compression ratio. RAM usage suggests a small table size. It may be simply splitting files into smaller chunks as it encodes. I haven't investigated the xdelta source personally to verify 100%.

With small files, performance difference is mostly negligible as per the blog.

I'm bringing those numbers up because your blog post focused a lot on comparing performance with xdelta.
Don't forget about compression efficiency; xdelta seems to drop off more the bigger the file size is, though I haven't sampled enough data to verify how strong that correlation is.


Other Notes
-------------

- The blog mentions `Span<T>` as a bottleneck. 

That kind of surprises me as creating a span in release mode is basically free.

See JIT Generated Code on Sharplab:
https://sharplab.io/#v2:C4LghgzgtgPgAgJgIwFgBQcAMACOSB0ASgK4B2wAllAKb4DCA9lAA4UA21ATgMpcBuFAMbUIAbnTo4AZlwJsdbAG902VdhVrp2MhDAAzatm7MwpADwAjAJ7BqAPmwBZABTXbAKmzMGFclwA02L7A2BykAObAABYAlOpoakoaiapwAOzYpNQA7kYm5m72zt7BAaHUEdEx4glqAL7odUA=


The only artifact of creating a Span is a bounds check (length < 0); otherwise it's basically 2 instructions.
```x86asm
L000c: mov [edx], ecx
L000e: mov [edx+4], eax
```

I wonder if the profiler may have something to do with that. Or maybe it was running in Debug; I don't know.

That said, although it's been a while that I've experimented with SIMD, I do remember there being a noticeable performance  difference in using the the more generic `Vector<T>` over a specific instruction set implementation i.e. `Avx2`. I would prefer to believe the bigger performance difference came from here.

*What is actually not free, is generating a Span from `Memory<T>`*:
https://sharplab.io/#v2:C4LghgzgtgPgAgJgIwFgBQcAMACOSB0ASgK4B2wAllAKb4DCA9lAA4UA21ATgMpcBuFAMbUIAbnTo4AZlwJsdbAG902VdhVrp2MhDAAzatm7MwpADwAjAJ7BqAPmwBZABSPqUBpytmAQjfvYACZgwGAAlOpoakoa0apwAOxBIWD4xqbiUWoAvujZQA==

You're not the only one :) https://stackoverflow.com/questions/56285370/c-sharp-memory-span-unexpectedly-slow
Due to some special handling resulting by the fact that `Memory<T>` can also hold managed types, not only `unmanaged` ones.

Edit: [Here's an extra](https://sharplab.io/#v2:C4LghgzgtgPgAgJgIwFgBQcAMACOSB0ASgK4B2wAllAKb4DCA9lAA4UA21ATgMpcBuFAMbUIAbnRZcBEuSq0AkuS4NmvTgOFj0EgMy4E2OtgDe6bOexmLAemuGGpPl2ARsAWWpQGnAJ4AeACMfYGoAPmwKcgZsbmYwUkDgsKtzOD0yCDAAM2oYuISgkPCAQTYvCGAAMU5qagB1CmAACwAJMEEAawgACg8vX0Si7AATMGAwAEpLNAsTFNnsW2xiiAhiGlcKzmJBYGw2MB8GYlB52aWcAF5sAHkAgCtqXbObOwgKAC9qBizu0kjgFNrophtQAB4vcyQxZ2ADi1D2fW8/gAKuFOGAAO4jMZgfDQvhgTg48YABWAxPM126imA5M4UwAqqRMjl8CtSQwAVxujUsiTJuIZgsocKRUt4XsyKDOGwfJEAObYIkYnz4sULQnEhgPJ50inYa4AKhp5HpRqmozJFKFIvMWuVnFVC2uzNZtBWflp9IANNhCtQANoAXVCvOo/J1j129Imtrt0IlCOwfK41FIwmwwGiSAq2CjevVdpTEewDr5KIYhARxE4pENJf5SN8biJECaYDY+ElxSdhwAIrjqzkahnqN0VYc49oNec4cmwMNhjVVvn+RUiXsfnl4kW7RWqzW6w2+dg3dkPUvw/yD9XgLXSH6TQCLd0rWB6dgANTYd5fH5/ACEzAfGIrQnAADs7ieMiracO2nb0DUYzULE8TXo2lZ3g+fqTmqAAy6YKs004agAvugZFAA==)

Untested. Just to show the idea. Relies on runtime implementation, would not recommend.