### PR TITLE
Add netstandard2.0 support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,7 +41,7 @@ jobs:
       run: dotnet test --no-build --configuration ${{ matrix.configuration }} src
       continue-on-error: ${{ matrix.os == 'macos-latest' }}
     - name: Tests (Full Framework)
-      run: dotnet test --no-build --configuration ${{ matrix.configuration }} src/VCDiff.Tests/VCDiff.Tests.NetFx.csproj
+      run: dotnet test --configuration ${{ matrix.configuration }} src/VCDiff.Tests/VCDiff.Tests.NetFx.csproj
       if: ${{ matrix.os == 'windows-latest' }}
     - name: Upload code coverage
       uses: codecov/codecov-action@v1.2.1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Tests
       run: dotnet test --no-build --configuration ${{ matrix.configuration }} src
       continue-on-error: ${{ matrix.os == 'macos-latest' }}
+    - name: Tests (Full Framework)
+      run: dotnet test --no-build --configuration ${{ matrix.configuration }} src/VCDiff.Tests/VCDiff.Tests.NetFx.csproj
+      if: ${{ matrix.os == 'windows-latest' }}
     - name: Upload code coverage
       uses: codecov/codecov-action@v1.2.1
       with:

--- a/src/VCDiff.Tests/VCDiff.Tests.NetFx.csproj
+++ b/src/VCDiff.Tests/VCDiff.Tests.NetFx.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="VCDiff.Tests.csproj" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net48</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/VCDiff.Tests/VCDiff.Tests.csproj
+++ b/src/VCDiff.Tests/VCDiff.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/VCDiff.Tests/VCDiff.Tests.csproj
+++ b/src/VCDiff.Tests/VCDiff.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/VCDiff/Encoders/BlockHash.cs
+++ b/src/VCDiff/Encoders/BlockHash.cs
@@ -302,7 +302,7 @@ namespace VCDiff.Encoders
                     }
                 }
             }
-#else
+#elif NETSTANDARD2_1
             int vectorSize = Vector<byte>.Count;
             if (lengthToExamine >= vectorSize)
             {
@@ -476,7 +476,7 @@ namespace VCDiff.Encoders
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe long MatchingBytesToLeft(long start, long tstart, byte* sourcePtr, byte* targetPtr, ByteBuffer target, long maxBytes)
         {
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET5_0 || NET5_0_OR_GREATER
             if (Avx2.IsSupported) return MatchingBytesToLeftAvx2(start, tstart, sourcePtr, targetPtr, maxBytes);
             if (Sse2.IsSupported) return MatchingBytesToLeftSse2(start, tstart, sourcePtr, targetPtr, maxBytes);
 #endif
@@ -490,6 +490,7 @@ namespace VCDiff.Encoders
             var tBuf = target.AsSpan();
             var sBuf = source.AsSpan();
 
+#if NETCOREAPP3_1 || NET5_0 || NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             while (sindex >= vectorSize && tindex >= vectorSize && bytesFound <= maxBytes - vectorSize)
             {
                 tindex -= vectorSize;
@@ -505,6 +506,7 @@ namespace VCDiff.Encoders
 
                 bytesFound += vectorSize;
             }
+#endif
 
             while (bytesFound < maxBytes)
             {
@@ -624,6 +626,8 @@ namespace VCDiff.Encoders
             long trgLength = target.Length;
             byte* tPtr = targetPtr;
             byte* sPtr = sourcePtr;
+
+#if NETCOREAPP3_1 || NET5_0 || NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             int vectorSize = Vector<byte>.Count;
             var tBuf = target.AsSpan();
             var sBuf = source.AsSpan();
@@ -641,6 +645,7 @@ namespace VCDiff.Encoders
                 tindex += vectorSize;
                 sindex += vectorSize;
             }
+#endif
 
             while (bytesFound < maxBytes)
             {

--- a/src/VCDiff/Encoders/InstructionMap.cs
+++ b/src/VCDiff/Encoders/InstructionMap.cs
@@ -114,7 +114,7 @@ namespace VCDiff.Encoders
             private int[] NewSizeOpcodeArray(int size)
             {
                 int[] nn = new int[size];
-                Array.Fill(nn, CodeTable.kNoOpcode);
+                new Span<int>(nn).Fill(CodeTable.kNoOpcode);
                 return nn;
             }
 
@@ -147,8 +147,7 @@ namespace VCDiff.Encoders
                 this.maxSize = maxSize + 1;
                 this.numInstAndModes = numInstAndModes;
                 opcodes = new int[numInstAndModes * this.maxSize];
-
-                Array.Fill(opcodes, CodeTable.kNoOpcode);
+                new Span<int>(opcodes).Fill(CodeTable.kNoOpcode);
             }
 
             public void Add(byte inst, byte size, byte mode, byte opcode)

--- a/src/VCDiff/Shared/Intrinsics.cs
+++ b/src/VCDiff/Shared/Intrinsics.cs
@@ -65,7 +65,7 @@ namespace VCDiff.Shared
             }
 #else
             // Accelerate via loop unrolled solution.
-            MemoryMarshal.CreateSpan(ref Unsafe.AsRef<long>((void*) first), numValues).Fill(value);
+            new Span<long>((void*)first, numValues).Fill(value);
 #endif
         }
 

--- a/src/VCDiff/VCDiff.csproj
+++ b/src/VCDiff/VCDiff.csproj
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <RootNamespace>VCDiff</RootNamespace>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Version>4.0.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,8 +21,14 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" Condition="$(TargetFramework.StartsWith('netstandard'))" />
+    <PackageReference Include="PolyShim" Version="1.8.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
It is trivial to add netstandard2.0 support with a few small changes. This allows the usage of the library in the .net full framework. I also fixed a bug in the MatchingBytesToLeft method, where vector extensions were not being used on net6 and up.